### PR TITLE
Add --from-date and --to-date to query and export command

### DIFF
--- a/osxphotos/photosdb.py
+++ b/osxphotos/photosdb.py
@@ -1318,6 +1318,8 @@ class PhotosDB:
         albums=None,
         images=True,
         movies=False,
+        from_date=None,
+        to_date=None,
     ):
         """ 
         Return a list of PhotoInfo objects
@@ -1328,7 +1330,7 @@ class PhotosDB:
         movies: if True, returns movie files, if False, does not return movies; default is False
         """
         photos_sets = []  # list of photo sets to perform intersection of
-        if not keywords and not uuid and not persons and not albums:
+        if not any([keywords, uuid, persons, albums, from_date, to_date]):
             # return all the photos, filtering for images and movies
             # append keys of all photos as a single set to photos_sets
             photos_sets.append(set(self._dbphotos.keys()))
@@ -1372,6 +1374,19 @@ class PhotosDB:
                         photos_sets.append(set(self._dbfaces_person[person]))
                     else:
                         logging.debug(f"Could not find person '{person}' in database")
+            if from_date or to_date:
+                dsel = self._dbphotos
+                if from_date:
+                    dsel = {
+                        k: v for k, v in dsel.items() if v["imageDate"] >= from_date
+                    }
+                    logging.debug(
+                        f"Found %i items with from_date {from_date}" % len(dsel)
+                    )
+                if to_date:
+                    dsel = {k: v for k, v in dsel.items() if v["imageDate"] <= to_date}
+                    logging.debug(f"Found %i items with to_date {to_date}" % len(dsel))
+                photos_sets.append(set(dsel.keys()))
 
         photoinfo = []
         if photos_sets:  # found some photos

--- a/tests/test_catalina_10_15_1.py
+++ b/tests/test_catalina_10_15_1.py
@@ -786,3 +786,20 @@ def test_photosinfo_repr():
         k: str(v).encode("utf-8")
         for k, v in photo2.__dict__.items()
     }
+
+
+def test_from_to_date():
+    import osxphotos
+    import datetime as dt
+
+    photosdb = osxphotos.PhotosDB(PHOTOS_DB)
+
+    photos = photosdb.photos(from_date=dt.datetime(2018, 10, 28))
+    assert len(photos) == 2
+
+    photos = photosdb.photos(to_date=dt.datetime(2018, 10, 28))
+    assert len(photos) == 5
+
+    photos = photosdb.photos(from_date=dt.datetime(2018, 9, 28),
+                             to_date=dt.datetime(2018, 9, 29))
+    assert len(photos) == 4

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -103,3 +103,25 @@ def test_export():
         )
         files = glob.glob("*.jpg")
         assert files.sort() == CLI_EXPORT_FILENAMES.sort()
+
+
+def test_query_date():
+    import json
+    import osxphotos
+    from osxphotos.__main__ import query
+
+    runner = CliRunner()
+    result = runner.invoke(
+        query,
+        [
+            "--json",
+            "--db",
+            "./tests/Test-10.15.1.photoslibrary",
+            "--from-date=2018-09-28",
+            "--to-date=2018-09-28T23:00:00"
+        ],
+    )
+    assert result.exit_code == 0
+
+    json_got = json.loads(result.output)
+    assert len(json_got) == 4


### PR DESCRIPTION
This is implemented in the `PhotosDB.photos` method and then used in the `__main__.py:_query` function. Tested on a DB with 28k items with reasonable performance (~5 sec writing out about half of the items with `query`).

The CLI definition is further refactored as well.