### PR TITLE
My photolibrary has at least one imageDate is way out of range.

### DIFF
--- a/osxphotos/photosdb/photosdb.py
+++ b/osxphotos/photosdb/photosdb.py
@@ -1517,7 +1517,13 @@ class PhotosDB:
             else:
                 info["lastmodifieddate"] = None
 
-            info["imageDate"] = datetime.fromtimestamp(row[5] + td)
+            # Sometimes the year is waaay out of range (82665413681585!) so
+            # like lastmodifieddate, skip setting this if it is out of whack
+            #
+            if row[5] is not None and row[5] <= 9999999999:
+                info["imageDate"] = datetime.fromtimestamp(row[5] + td)
+            else:
+                info["imageDate"] = None
             info["imageTimeZoneOffsetSeconds"] = row[6]
             info["hidden"] = row[9]
             info["favorite"] = row[10]


### PR DESCRIPTION
Had an imageDate value that was `82665413681585` (instead of the more normal `580188704`) so seeing that you set `lastmodifieddate` to None on bad values I did the same for `imageDate`