### PR TITLE
Catch illegal timestamp value

### DIFF
--- a/osxphotos/photosdb/photosdb.py
+++ b/osxphotos/photosdb/photosdb.py
@@ -805,7 +805,11 @@ class PhotosDB:
             else:
                 self._dbphotos[uuid]["lastmodifieddate"] = None
 
-            self._dbphotos[uuid]["imageDate"] = datetime.fromtimestamp(row[5] + td)
+            try:
+                self._dbphotos[uuid]["imageDate"] = datetime.fromtimestamp(row[5] + td)
+            except ValueError:
+                self._dbphotos[uuid]["imageDate"] = datetime.date(1970,1,1)
+
             self._dbphotos[uuid]["mainRating"] = row[6]
             self._dbphotos[uuid]["hasAdjustments"] = row[7]
             self._dbphotos[uuid]["hasKeywords"] = row[8]


### PR DESCRIPTION
When using this on my Photos database, it threw a ValueError. I wrapped the fromtimestamp() call in a try block so that it would continue with the oldest date allowable.