### PR TITLE
Don't raise KeyError when SystemLibraryPath is absent

### DIFF
--- a/osxphotos/utils.py
+++ b/osxphotos/utils.py
@@ -169,7 +169,7 @@ def get_system_library_path():
         logging.warning(f"could not find plist file: {str(plist_file)}")
         return None
 
-    photospath = pl["SystemLibraryPath"]
+    photospath = pl.get("SystemLibraryPath")
 
     if photospath is not None:
         return photospath


### PR DESCRIPTION
Currently, the function expects to always find `SystemLibraryPath` if MacOS > 10.15. Weirdly, on my clean install of macOS Catalina (clean install with 10.15.1, upgraded to 10.15.5), my photos library is set correctly as System Photo Library but the key is not present in the PLIST file.

This PR fixes the issue by making sure that the function doesn't raise an exception. Although, it also means that it will not be able to find the System Photo Library.

```sh
$ osxphotos list
2020-06-18 23:56:49,882 - WARNING - utils.py - 177 - Could not get path to Photos database
	/Users/dethi/Desktop/playground/osxphotos/tests/Empty-Library-4.0-3461.7.150.photoslibrary
	/Users/dethi/Desktop/playground/osxphotos/tests/Test-10.12.6.photoslibrary
	/Users/dethi/Desktop/playground/osxphotos/tests/Test-10.13.6.photoslibrary
	/Users/dethi/Desktop/playground/osxphotos/tests/Test-10.14.5.photoslibrary
	/Users/dethi/Desktop/playground/osxphotos/tests/Test-10.14.6-path_edited.photoslibrary
	/Users/dethi/Desktop/playground/osxphotos/tests/Test-10.14.6.photoslibrary
	/Users/dethi/Desktop/playground/osxphotos/tests/Test-10.15.1.photoslibrary
	/Users/dethi/Desktop/playground/osxphotos/tests/Test-10.15.4.photoslibrary
	/Users/dethi/Desktop/playground/osxphotos/tests/Test-10.15.5.photoslibrary
	/Users/dethi/Desktop/playground/osxphotos/tests/Test-Cloud-10.14.6.photoslibrary
	/Users/dethi/Desktop/playground/osxphotos/tests/Test-Cloud-10.15.1.photoslibrary
	/Users/dethi/Desktop/playground/osxphotos/tests/Test-Lock-10_12.photoslibrary
	/Users/dethi/Desktop/playground/osxphotos/tests/Test-Lock-10_15_1.photoslibrary
	/Users/dethi/Desktop/playground/osxphotos/tests/Test-Movie-4_0.photoslibrary
	/Users/dethi/Desktop/playground/osxphotos/tests/Test-Movie-5_0.photoslibrary
	/Users/dethi/Desktop/playground/osxphotos/tests/Test-Places-Catalina-10_15_1.photoslibrary
	/Users/dethi/Desktop/playground/osxphotos/tests/Test-Places-High-Sierra-10.13.6.photoslibrary
	/Users/dethi/Desktop/playground/osxphotos/tests/Test-RAW-10.15.1.photoslibrary
	/Users/dethi/Desktop/playground/osxphotos/tests/Test-Shared-10.15.1.photoslibrary
(#)	/Users/dethi/Pictures/Photos Library.photoslibrary


(#)	Last opened Photos Library
```

### Issue Detail

**macOS:** 10.15.5 (19F101)
**Photos:** 5.0 (151.19.150)

```sh
$ python --version
Python 3.8.3

$ osxphotos --version
osxphotos, version 0.29.19

$ osxphotos list
Traceback (most recent call last):
  File "/Users/dethi/Desktop/playground/.venv/bin/osxphotos", line 10, in <module>
    sys.exit(cli())
  File "/Users/dethi/Desktop/playground/.venv/lib/python3.8/site-packages/click/core.py", line 829, in __call__
    return self.main(*args, **kwargs)
  File "/Users/dethi/Desktop/playground/.venv/lib/python3.8/site-packages/click/core.py", line 782, in main
    rv = self.invoke(ctx)
  File "/Users/dethi/Desktop/playground/.venv/lib/python3.8/site-packages/click/core.py", line 1259, in invoke
    return _process_result(sub_ctx.command.invoke(sub_ctx))
  File "/Users/dethi/Desktop/playground/.venv/lib/python3.8/site-packages/click/core.py", line 1066, in invoke
    return ctx.invoke(self.callback, **ctx.params)
  File "/Users/dethi/Desktop/playground/.venv/lib/python3.8/site-packages/click/core.py", line 610, in invoke
    return callback(*args, **kwargs)
  File "/Users/dethi/Desktop/playground/.venv/lib/python3.8/site-packages/click/decorators.py", line 33, in new_func
    return f(get_current_context().obj, *args, **kwargs)
  File "/Users/dethi/Desktop/playground/.venv/lib/python3.8/site-packages/click/decorators.py", line 21, in new_func
    return f(get_current_context(), *args, **kwargs)
  File "/Users/dethi/Desktop/playground/.venv/lib/python3.8/site-packages/osxphotos/__main__.py", line 775, in list_libraries
    _list_libraries(json_=json_ or cli_obj.json, error=False)
  File "/Users/dethi/Desktop/playground/.venv/lib/python3.8/site-packages/osxphotos/__main__.py", line 783, in _list_libraries
    sys_lib = osxphotos.utils.get_system_library_path()
  File "/Users/dethi/Desktop/playground/.venv/lib/python3.8/site-packages/osxphotos/utils.py", line 172, in get_system_library_path
    photospath = pl["SystemLibraryPath"]
KeyError: 'SystemLibraryPath'
```

![image](https://user-images.githubusercontent.com/1011520/85079390-9a5e5f00-b1be-11ea-94aa-d8152793017c.png)

```sh
$ plutil -p ~/Library/Containers/com.apple.photolibraryd/Data/Library/Preferences/com.apple.photolibraryd.plist
{
  "com.apple.photolibraryd.purgeNotification.purge_markers" => {
    "046FDDF8-6220-48D2-ADB2-D8F0FA249C85" => [
      0 => "67E9D824-5616-4B68-998A-2D005CFA6225"
      1 => 156742943
    ]
  }
  "kPLPhotoStreamMPSStateNextCheckDateKey" => 2020-06-19 21:27:58 +0000
  "PLBackgroundJobServiceBundleRecordsHighPriorityKey" => [
  ]
  "PLBackgroundJobServiceBundleRecordsLowPriorityKey" => [
  ]
  "PLDeviceDataFeedbackDate" => 2019-12-26 15:48:30 +0000
  "PLLibraryBookmarkManagerBookmarksByPath" => {
    "/Users/dethi/Desktop/TestsLibrary.photoslibrary" => {length = 712, bytes = 0x626f6f6b c8020000 00000410 30000000 ... 04000000 00000000 }
    "/Users/dethi/Pictures/Photos Library.photoslibrary" => {length = 712, bytes = 0x626f6f6b c8020000 00000410 30000000 ... 04000000 00000000 }
  }
}
```