### PR TITLE
Revert "Fix FileExistsError when filename differs only in case and export-as-hardlink (Bug#133)"

### DIFF
--- a/osxphotos/photoinfo/_photoinfo_export.py
+++ b/osxphotos/photoinfo/_photoinfo_export.py
@@ -34,7 +34,7 @@ from .._constants import (
 from .._export_db import ExportDBNoOp
 from ..exiftool import ExifTool
 from ..fileutil import FileUtil
-from ..utils import dd_to_dms_str, findfiles
+from ..utils import dd_to_dms_str
 
 ExportResults = namedtuple(
     "ExportResults", ["exported", "new", "updated", "skipped", "exif_updated"]
@@ -428,10 +428,11 @@ def export2(
     # dest will be file1 (1).jpeg even though file1.jpeg doesn't exist to prevent sidecar collision
     if not update and increment and not overwrite:
         count = 1
-        dest_files = findfiles(f"{dest.stem}*", str(dest.parent))
-        dest_files = [pathlib.Path(f).stem.lower() for f in dest_files]
+        glob_str = str(dest.parent / f"{dest.stem}*")
+        dest_files = glob.glob(glob_str)
+        dest_files = [pathlib.Path(f).stem for f in dest_files]
         dest_new = dest.stem
-        while dest_new.lower() in dest_files:
+        while dest_new in dest_files:
             dest_new = f"{dest.stem} ({count})"
             count += 1
         dest = dest.parent / f"{dest_new}{dest.suffix}"


### PR DESCRIPTION
Reverts RhetTbull/osxphotos#190

causes test failure for --dry-run:
tests/test_cli.py::test_export_directory_template_1_dry_run

```python
======================================================= FAILURES =======================================================
_______________________________________ test_export_directory_template_1_dry_run _______________________________________

    def test_export_directory_template_1_dry_run():
        """ test export using directory template with dry-run flag """
        import glob
        import locale
        import os
        import os.path
        import osxphotos
        from osxphotos.__main__ import export

        locale.setlocale(locale.LC_ALL, "en_US")

        runner = CliRunner()
        cwd = os.getcwd()
        # pylint: disable=not-context-manager
        with runner.isolated_filesystem():
            result = runner.invoke(
                export,
                [
                    os.path.join(cwd, CLI_PHOTOS_DB),
                    ".",
                    "-V",
                    "--directory",
                    "{created.year}/{created.month}",
                    "--dry-run",
                ],
            )
>           assert result.exit_code == 0
E           AssertionError: assert 1 == 0
E            +  where 1 = <Result FileNotFoundError(2, 'No such file or directory')>.exit_code

tests/test_cli.py:2405: AssertionError
```