### PR TITLE
Fix findfiles not to fail on missing/invalid dir

### DIFF
--- a/osxphotos/utils.py
+++ b/osxphotos/utils.py
@@ -262,7 +262,10 @@ def get_preferred_uti_extension(uti):
 
 def findfiles(pattern, path_):
     """Returns list of filenames from path_ matched by pattern
-       shell pattern. Matching is case-insensitive."""
+       shell pattern. Matching is case-insensitive.
+       If 'path_' is invalid/doesn't exist, returns []."""
+    if not os.path.isdir(path_):
+        return []
     # See: https://gist.github.com/techtonik/5694830
 
     rule = re.compile(fnmatch.translate(pattern), re.IGNORECASE)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -76,3 +76,13 @@ def test_findfiles():
     assert len(files) == 2
     assert "file1.jpg" in files
     assert "file2.JPG" in files
+
+
+def test_findfiles_invalid_dir():
+    import tempfile
+    import os.path
+    from osxphotos.utils import findfiles
+
+    temp_dir = tempfile.TemporaryDirectory(prefix="osxphotos_")
+    files = findfiles("*.jpg", f"{temp_dir.name}/no_such_dir" )
+    assert len(files) == 0


### PR DESCRIPTION
Was failing on --dry-run and tests.
Added unit-test.