### PR TITLE
Ensure keyword list only contains strings

### DIFF
--- a/osxphotos/photoinfo/_photoinfo_export.py
+++ b/osxphotos/photoinfo/_photoinfo_export.py
@@ -1443,7 +1443,7 @@ def _exiftool_dict(
 
     if keyword_list:
         # remove duplicates
-        keyword_list = sorted(list(set(keyword_list)))
+        keyword_list = sorted(list(set([str(keyword) for keyword in keyword_list])))
         exif["IPTC:Keywords"] = keyword_list.copy()
         exif["XMP:Subject"] = keyword_list.copy()
         exif["XMP:TagsList"] = keyword_list.copy()


### PR DESCRIPTION
Hi

I ran into an issue when using flags fetching keywords from multiple of the available sources were one or more keyword ended up in the `keyword_list` variable as an integer, this means that the call to `sorted` would fail as strings and integers cant be compared.

This fix ensures that the list only contains strings before trying to sort. 
However, I do not think this is the fastest/optimal solution. I might be better to ensure that all the individual lists added to `keyword_list` is only containing strings.

Happy to help debugging more, I didn't have too much time looking into this, but it is coming from activating one of the following keyword flags:

```toml
[export]
exiftool = true
exiftool_merge_keywords = true
exiftool_merge_persons = true
finder_tag_keywords = true
keyword_template = [ "{place.name.country}", "{place.name.area_of_interest}", "{place.name.city}", "{place.name.state_province}", "{searchinfo.venue_type}", "{searchinfo.venue}", "{searchinfo.activity}", "{searchinfo.holiday}", "{searchinfo.season}",]
person_keyword = true
```


