### PR TITLE
Use original filename to export photos by default

### DIFF
--- a/osxphotos/photoinfo/_photoinfo_export.py
+++ b/osxphotos/photoinfo/_photoinfo_export.py
@@ -613,7 +613,7 @@ def export2(
                 )
             edited_name = pathlib.Path(self.path_edited).name
             edited_suffix = pathlib.Path(edited_name).suffix
-            fname = pathlib.Path(self.filename).stem + edited_identifier + edited_suffix
+            fname = pathlib.Path(self.original_filename).stem + edited_identifier + edited_suffix
         else:
             fname = self.original_filename
 

--- a/osxphotos/photoinfo/_photoinfo_export.py
+++ b/osxphotos/photoinfo/_photoinfo_export.py
@@ -613,7 +613,7 @@ def export2(
                 )
             edited_name = pathlib.Path(self.path_edited).name
             edited_suffix = pathlib.Path(edited_name).suffix
-            fname = pathlib.Path(self.original_filename).stem + edited_identifier + edited_suffix
+            fname = pathlib.Path(self.filename).stem + edited_identifier + edited_suffix
         else:
             fname = self.original_filename
 

--- a/osxphotos/photoinfo/_photoinfo_export.py
+++ b/osxphotos/photoinfo/_photoinfo_export.py
@@ -615,7 +615,7 @@ def export2(
             edited_suffix = pathlib.Path(edited_name).suffix
             fname = pathlib.Path(self.filename).stem + edited_identifier + edited_suffix
         else:
-            fname = self.filename
+            fname = self.original_filename
 
     uti = self.uti if edited else self.uti_original
     if convert_to_jpeg and self.isphoto and uti != "public.jpeg":

--- a/tests/test_bigsur_10_16_0.py
+++ b/tests/test_bigsur_10_16_0.py
@@ -994,7 +994,7 @@ def test_export_12():
 
     edited_name = pathlib.Path(photos[0].path_edited).name
     edited_suffix = pathlib.Path(edited_name).suffix
-    filename = pathlib.Path(photos[0].filename).stem + "_edited" + edited_suffix
+    filename = pathlib.Path(photos[0].original_filename).stem + "_edited" + edited_suffix
     expected_dest = os.path.join(dest, filename)
 
     got_dest = photos[0].export(dest, edited=True)[0]

--- a/tests/test_bigsur_10_16_0.py
+++ b/tests/test_bigsur_10_16_0.py
@@ -731,7 +731,7 @@ def test_export_1():
     photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     expected_dest = os.path.join(dest, filename)
     got_dest = photos[0].export(dest)[0]
 
@@ -776,7 +776,7 @@ def test_export_3():
     photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     filename2 = pathlib.Path(filename)
     filename2 = f"{filename2.stem} (1){filename2.suffix}"
     expected_dest_2 = os.path.join(dest, filename2)
@@ -829,7 +829,7 @@ def test_export_5():
     photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     expected_dest = os.path.join(dest, filename)
 
     got_dest = photos[0].export(dest)[0]

--- a/tests/test_bigsur_10_16_0_1.py
+++ b/tests/test_bigsur_10_16_0_1.py
@@ -848,7 +848,7 @@ def test_export_12(photosdb):
 
     edited_name = pathlib.Path(photos[0].path_edited).name
     edited_suffix = pathlib.Path(edited_name).suffix
-    filename = pathlib.Path(photos[0].filename).stem + "_edited" + edited_suffix
+    filename = pathlib.Path(photos[0].original_filename).stem + "_edited" + edited_suffix
     expected_dest = os.path.join(dest, filename)
 
     got_dest = photos[0].export(dest, edited=True)[0]

--- a/tests/test_bigsur_10_16_0_1.py
+++ b/tests/test_bigsur_10_16_0_1.py
@@ -618,7 +618,7 @@ def test_export_1(photosdb):
     dest = tempdir.name
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     expected_dest = os.path.join(dest, filename)
     got_dest = photos[0].export(dest)[0]
 
@@ -657,7 +657,7 @@ def test_export_3(photosdb):
     dest = tempdir.name
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     filename2 = pathlib.Path(filename)
     filename2 = f"{filename2.stem} (1){filename2.suffix}"
     expected_dest_2 = os.path.join(dest, filename2)
@@ -704,7 +704,7 @@ def test_export_5(photosdb):
     dest = tempdir.name
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     expected_dest = os.path.join(dest, filename)
 
     got_dest = photos[0].export(dest)[0]

--- a/tests/test_catalina_10_15_1.py
+++ b/tests/test_catalina_10_15_1.py
@@ -418,7 +418,7 @@ def test_export_1():
     photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     expected_dest = os.path.join(dest, filename)
     got_dest = photos[0].export(dest)[0]
 
@@ -463,7 +463,7 @@ def test_export_3():
     photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     filename2 = pathlib.Path(filename)
     filename2 = f"{filename2.stem} (1){filename2.suffix}"
     expected_dest_2 = os.path.join(dest, filename2)
@@ -516,7 +516,7 @@ def test_export_5():
     photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     expected_dest = os.path.join(dest, filename)
 
     got_dest = photos[0].export(dest)[0]

--- a/tests/test_catalina_10_15_1.py
+++ b/tests/test_catalina_10_15_1.py
@@ -681,7 +681,7 @@ def test_export_12():
 
     edited_name = pathlib.Path(photos[0].path_edited).name
     edited_suffix = pathlib.Path(edited_name).suffix
-    filename = pathlib.Path(photos[0].filename).stem + "_edited" + edited_suffix
+    filename = pathlib.Path(photos[0].original_filename).stem + "_edited" + edited_suffix
     expected_dest = os.path.join(dest, filename)
 
     got_dest = photos[0].export(dest, edited=True)[0]

--- a/tests/test_catalina_10_15_4.py
+++ b/tests/test_catalina_10_15_4.py
@@ -426,7 +426,7 @@ def test_export_1():
     photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     expected_dest = os.path.join(dest, filename)
     got_dest = photos[0].export(dest)[0]
 
@@ -471,7 +471,7 @@ def test_export_3():
     photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     filename2 = pathlib.Path(filename)
     filename2 = f"{filename2.stem} (1){filename2.suffix}"
     expected_dest_2 = os.path.join(dest, filename2)
@@ -524,7 +524,7 @@ def test_export_5():
     photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     expected_dest = os.path.join(dest, filename)
 
     got_dest = photos[0].export(dest)[0]

--- a/tests/test_catalina_10_15_4.py
+++ b/tests/test_catalina_10_15_4.py
@@ -689,7 +689,7 @@ def test_export_12():
 
     edited_name = pathlib.Path(photos[0].path_edited).name
     edited_suffix = pathlib.Path(edited_name).suffix
-    filename = pathlib.Path(photos[0].filename).stem + "_edited" + edited_suffix
+    filename = pathlib.Path(photos[0].original_filename).stem + "_edited" + edited_suffix
     expected_dest = os.path.join(dest, filename)
 
     got_dest = photos[0].export(dest, edited=True)[0]

--- a/tests/test_catalina_10_15_5.py
+++ b/tests/test_catalina_10_15_5.py
@@ -903,7 +903,7 @@ def test_export_12():
 
     edited_name = pathlib.Path(photos[0].path_edited).name
     edited_suffix = pathlib.Path(edited_name).suffix
-    filename = pathlib.Path(photos[0].filename).stem + "_edited" + edited_suffix
+    filename = pathlib.Path(photos[0].original_filename).stem + "_edited" + edited_suffix
     expected_dest = os.path.join(dest, filename)
 
     got_dest = photos[0].export(dest, edited=True)[0]

--- a/tests/test_catalina_10_15_5.py
+++ b/tests/test_catalina_10_15_5.py
@@ -640,7 +640,7 @@ def test_export_1():
     photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     expected_dest = os.path.join(dest, filename)
     got_dest = photos[0].export(dest)[0]
 
@@ -685,7 +685,7 @@ def test_export_3():
     photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     filename2 = pathlib.Path(filename)
     filename2 = f"{filename2.stem} (1){filename2.suffix}"
     expected_dest_2 = os.path.join(dest, filename2)
@@ -738,7 +738,7 @@ def test_export_5():
     photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     expected_dest = os.path.join(dest, filename)
 
     got_dest = photos[0].export(dest)[0]

--- a/tests/test_catalina_10_15_6.py
+++ b/tests/test_catalina_10_15_6.py
@@ -823,7 +823,7 @@ def test_export_12(photosdb):
 
     edited_name = pathlib.Path(photos[0].path_edited).name
     edited_suffix = pathlib.Path(edited_name).suffix
-    filename = pathlib.Path(photos[0].filename).stem + "_edited" + edited_suffix
+    filename = pathlib.Path(photos[0].original_filename).stem + "_edited" + edited_suffix
     expected_dest = os.path.join(dest, filename)
 
     got_dest = photos[0].export(dest, edited=True)[0]

--- a/tests/test_catalina_10_15_6.py
+++ b/tests/test_catalina_10_15_6.py
@@ -635,7 +635,7 @@ def test_export_1(photosdb):
     dest = tempdir.name
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     expected_dest = os.path.join(dest, filename)
     got_dest = photos[0].export(dest)[0]
 
@@ -666,7 +666,7 @@ def test_export_3(photosdb):
     dest = tempdir.name
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     filename2 = pathlib.Path(filename)
     filename2 = f"{filename2.stem} (1){filename2.suffix}"
     expected_dest_2 = os.path.join(dest, filename2)
@@ -705,7 +705,7 @@ def test_export_5(photosdb):
     dest = tempdir.name
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     expected_dest = os.path.join(dest, filename)
 
     got_dest = photos[0].export(dest)[0]

--- a/tests/test_catalina_10_15_7.py
+++ b/tests/test_catalina_10_15_7.py
@@ -693,7 +693,7 @@ def test_export_1(photosdb):
     dest = tempdir.name
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     expected_dest = os.path.join(dest, filename)
     got_dest = photos[0].export(dest)[0]
 
@@ -724,7 +724,7 @@ def test_export_3(photosdb):
     dest = tempdir.name
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     filename2 = pathlib.Path(filename)
     filename2 = f"{filename2.stem} (1){filename2.suffix}"
     expected_dest_2 = os.path.join(dest, filename2)
@@ -763,7 +763,7 @@ def test_export_5(photosdb):
     dest = tempdir.name
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     expected_dest = os.path.join(dest, filename)
 
     got_dest = photos[0].export(dest)[0]

--- a/tests/test_catalina_10_15_7.py
+++ b/tests/test_catalina_10_15_7.py
@@ -881,7 +881,7 @@ def test_export_12(photosdb):
 
     edited_name = pathlib.Path(photos[0].path_edited).name
     edited_suffix = pathlib.Path(edited_name).suffix
-    filename = pathlib.Path(photos[0].filename).stem + "_edited" + edited_suffix
+    filename = pathlib.Path(photos[0].original_filename).stem + "_edited" + edited_suffix
     expected_dest = os.path.join(dest, filename)
 
     got_dest = photos[0].export(dest, edited=True)[0]

--- a/tests/test_export_catalina_10_15_7.py
+++ b/tests/test_export_catalina_10_15_7.py
@@ -95,7 +95,7 @@ def test_export_1(photosdb):
     dest = tempdir.name
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     expected_dest = os.path.join(dest, filename)
     got_dest = photos[0].export(dest)[0]
 
@@ -134,7 +134,7 @@ def test_export_3(photosdb):
     dest = tempdir.name
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     filename2 = pathlib.Path(filename)
     filename2 = f"{filename2.stem} (1){filename2.suffix}"
     expected_dest_2 = os.path.join(dest, filename2)
@@ -181,7 +181,7 @@ def test_export_5(photosdb):
     dest = tempdir.name
     photos = photosdb.photos(uuid=[UUID_DICT["export"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     expected_dest = os.path.join(dest, filename)
 
     got_dest = photos[0].export(dest)[0]

--- a/tests/test_export_catalina_10_15_7.py
+++ b/tests/test_export_catalina_10_15_7.py
@@ -326,7 +326,7 @@ def test_export_12(photosdb):
 
     edited_name = pathlib.Path(photos[0].path_edited).name
     edited_suffix = pathlib.Path(edited_name).suffix
-    filename = pathlib.Path(photos[0].filename).stem + "_edited" + edited_suffix
+    filename = pathlib.Path(photos[0].original_filename).stem + "_edited" + edited_suffix
     expected_dest = os.path.join(dest, filename)
 
     got_dest = photos[0].export(dest, edited=True)[0]

--- a/tests/test_export_raw_catalina_10_15_1.py
+++ b/tests/test_export_raw_catalina_10_15_1.py
@@ -101,7 +101,7 @@ def test_export_edited_default():
     photos = photosdb.photos(uuid=[UUID_DICT["has_adjustments"]])
 
     got_dest = photos[0].export(dest, edited=True)[0]
-    assert pathlib.Path(got_dest).name == FILENAME_DICT["current_edited"]
+    assert pathlib.Path(got_dest).name == FILENAME_DICT["original_edited"]
 
 
 def test_export_edited_wrong_suffix():

--- a/tests/test_export_raw_catalina_10_15_1.py
+++ b/tests/test_export_raw_catalina_10_15_1.py
@@ -29,13 +29,13 @@ def test_export_1():
     photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
     photos = photosdb.photos(uuid=[UUID_DICT["has_adjustments"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     expected_dest = os.path.join(dest, filename)
     got_dest = photos[0].export(dest)[0]
 
     assert got_dest == expected_dest
     assert os.path.isfile(got_dest)
-    assert pathlib.Path(got_dest).name == FILENAME_DICT["current"]
+    assert pathlib.Path(got_dest).name == FILENAME_DICT["original"]
 
 
 def test_export_2():

--- a/tests/test_live_catalina_10_15_1.py
+++ b/tests/test_live_catalina_10_15_1.py
@@ -44,7 +44,7 @@ def test_export_live_1():
     photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
     photos = photosdb.photos(uuid=[UUID_DICT["live"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     expected_dest = os.path.join(dest.name, filename)
     got_dest = photos[0].export(dest.name, live_photo=True)[0]
     got_movie = f"{pathlib.Path(got_dest).parent / pathlib.Path(got_dest).stem}.mov"
@@ -70,7 +70,7 @@ def test_export_live_2():
     photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
     photos = photosdb.photos(uuid=[UUID_DICT["live"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     expected_dest = os.path.join(dest.name, filename)
     got_dest = photos[0].export(dest.name, live_photo=False)[0]
     got_movie = f"{pathlib.Path(got_dest).parent / pathlib.Path(got_dest).stem}.mov"
@@ -97,7 +97,7 @@ def test_export_live_3():
     photosdb = osxphotos.PhotosDB(dbfile=PHOTOS_DB)
     photos = photosdb.photos(uuid=[UUID_DICT["live"]])
 
-    filename = photos[0].filename
+    filename = photos[0].original_filename
     expected_dest = os.path.join(dest.name, filename)
     expected_mov = f"{dest.name}/{pathlib.Path(expected_dest).stem}.mov"
     got_files = photos[0].export(dest.name, live_photo=True)


### PR DESCRIPTION
This tackles #176 by changing the export function to use the `original_filename` property, rather than the `filename` property. The latter has been mangled in recent versions of macOS, and is likely not to be what the user expects.

I have changed the relevant tests accordingly.