### PR TITLE
Fixes missing f-string to retry message

### DIFF
--- a/osxphotos/cli.py
+++ b/osxphotos/cli.py
@@ -2969,7 +2969,7 @@ def export_photo_to_directory(
                 break
             else:
                 click.echo(
-                    "Retrying export for photo ({photo.uuid}: {photo.original_filename})"
+                    f"Retrying export for photo ({photo.uuid}: {photo.original_filename})"
                 )
         except Exception as e:
             click.echo(


### PR DESCRIPTION
When using the `--retry` flag, the CLI's message isn't interpolated properly:

Current output is:
`Retrying export for photo ({photo.uuid}: {photo.original_filename})`

This PR adds the missing f-string that interpolates the uuid and filename properly.