### PR TITLE
Handle "Z" as EXIF offset time

### DIFF
--- a/osxphotos/exif_datetime_updater.py
+++ b/osxphotos/exif_datetime_updater.py
@@ -41,6 +41,11 @@ ExifDateTime = namedtuple(
 
 def exif_offset_to_seconds(offset: str) -> int:
     """Convert timezone offset from UTC in exiftool format (+/-hh:mm) to seconds"""
+
+    # Z (for Zulu time) corresponds to a zero UTC offset
+    if offset == "Z":
+        return 0
+
     sign = 1 if offset[0] == "+" else -1
     hours, minutes = offset[1:].split(":")
     return sign * (int(hours) * 3600 + int(minutes) * 60)


### PR DESCRIPTION
I have encountered the following error when using `timewarp --pull-exif` for several different pictures:

```
~ $ osxphotos timewarp --pull-exif --verbose --timestamp 2>&1 | tee -a osxphotoslog2.txt
2022-12-22 22:51:12.982003 -- exiftool path: /opt/homebrew/bin/exiftool
⚠️  About to process 1 photo with timewarp. This will directly modify your
Photos library database using undocumented features. While this functionality
has been well tested, it is possible this may corrupt, damage, or destroy your
Photos library. Use at your own caution. No warranty is implied or provided.
It is strongly recommended you make a backup of your Photos library before
using the timewarp command (for example, using Time Machine).

Proceed with timewarp? [y/N]: y
2022-12-22 22:51:18.261940 -- Updating Photos from EXIF data for IMG_0271.HEIC (F3E9A216-2DF3-41CE-AF98-CFA106460387)
╭─────────────────────────────── Traceback (most recent call last) ────────────────────────────────╮
│ /opt/homebrew/bin/osxphotos:8 in <module>                                                        │
│                                                                                                  │
│   5 from osxphotos.__main__ import cli_main                                                      │
│   6 if __name__ == '__main__':                                                                   │
│   7 │   sys.argv[0] = re.sub(r'(-script\.pyw|\.exe)?$', '', sys.argv[0])                         │
│ ❱ 8 │   sys.exit(cli_main())                                                                     │
│   9                                                                                              │
│                                                                                                  │
│ /opt/homebrew/lib/python3.10/site-packages/click/core.py:1130 in __call__                        │
│                                                                                                  │
│   1127 │                                                                                         │
│   1128 │   def __call__(self, *args: t.Any, **kwargs: t.Any) -> t.Any:                           │
│   1129 │   │   """Alias for :meth:`main`."""                                                     │
│ ❱ 1130 │   │   return self.main(*args, **kwargs)                                                 │
│   1131                                                                                           │
│   1132                                                                                           │
│   1133 class Command(BaseCommand):                                                               │
│                                                                                                  │
│ /opt/homebrew/lib/python3.10/site-packages/click/core.py:1055 in main                            │
│                                                                                                  │
│   1052 │   │   try:                                                                              │
│   1053 │   │   │   try:                                                                          │
│   1054 │   │   │   │   with self.make_context(prog_name, args, **extra) as ctx:                  │
│ ❱ 1055 │   │   │   │   │   rv = self.invoke(ctx)                                                 │
│   1056 │   │   │   │   │   if not standalone_mode:                                               │
│   1057 │   │   │   │   │   │   return rv                                                         │
│   1058 │   │   │   │   │   # it's not safe to `ctx.exit(rv)` here!                               │
│                                                                                                  │
│ /opt/homebrew/lib/python3.10/site-packages/click/core.py:1657 in invoke                          │
│                                                                                                  │
│   1654 │   │   │   │   super().invoke(ctx)                                                       │
│   1655 │   │   │   │   sub_ctx = cmd.make_context(cmd_name, args, parent=ctx)                    │
│   1656 │   │   │   │   with sub_ctx:                                                             │
│ ❱ 1657 │   │   │   │   │   return _process_result(sub_ctx.command.invoke(sub_ctx))               │
│   1658 │   │                                                                                     │
│   1659 │   │   # In chain mode we create the contexts step by step, but after the                │
│   1660 │   │   # base command has been invoked.  Because at that point we do not                 │
│                                                                                                  │
│ /opt/homebrew/lib/python3.10/site-packages/click/core.py:1404 in invoke                          │
│                                                                                                  │
│   1401 │   │   │   echo(style(message, fg="red"), err=True)                                      │
│   1402 │   │                                                                                     │
│   1403 │   │   if self.callback is not None:                                                     │
│ ❱ 1404 │   │   │   return ctx.invoke(self.callback, **ctx.params)                                │
│   1405 │                                                                                         │
│   1406 │   def shell_complete(self, ctx: Context, incomplete: str) -> t.List["CompletionItem"]:  │
│   1407 │   │   """Return a list of completions for the incomplete value. Looks                   │
│                                                                                                  │
│ /opt/homebrew/lib/python3.10/site-packages/click/core.py:760 in invoke                           │
│                                                                                                  │
│    757 │   │                                                                                     │
│    758 │   │   with augment_usage_errors(__self):                                                │
│    759 │   │   │   with ctx:                                                                     │
│ ❱  760 │   │   │   │   return __callback(*args, **kwargs)                                        │
│    761 │                                                                                         │
│    762 │   def forward(                                                                          │
│    763 │   │   __self, __cmd: "Command", *args: t.Any, **kwargs: t.Any  # noqa: B902             │
│                                                                                                  │
│ /opt/homebrew/lib/python3.10/site-packages/osxphotos/cli/timewarp.py:667 in timewarp             │
│                                                                                                  │
│   664 │   │   )                                                                                  │
│   665 │   │   for p in photos:                                                                   │
│   666 │   │   │   if pull_exif:                                                                  │
│ ❱ 667 │   │   │   │   exif_updater.update_photos_from_exif(                                      │
│   668 │   │   │   │   │   p, use_file_modify_date=use_file_time                                  │
│   669 │   │   │   │   )                                                                          │
│   670 │   │   │   if any([date, time, date_delta, time_delta]):                                  │
│                                                                                                  │
│ /opt/homebrew/lib/python3.10/site-packages/osxphotos/exif_datetime_updater.py:187 in             │
│ update_photos_from_exif                                                                          │
│                                                                                                  │
│   184 │   │   │   f"[filename]{photo.filename}[/filename] ([uuid]{photo.uuid}[/uuid])"           │
│   185 │   │   )                                                                                  │
│   186 │   │                                                                                      │
│ ❱ 187 │   │   dtinfo = self.get_date_time_offset_from_exif(                                      │
│   188 │   │   │   _photo.path, use_file_modify_date=use_file_modify_date                         │
│   189 │   │   )                                                                                  │
│   190 │   │   if dtinfo.used_file_modify_date:                                                   │
│                                                                                                  │
│ /opt/homebrew/lib/python3.10/site-packages/osxphotos/exif_datetime_updater.py:246 in             │
│ get_date_time_offset_from_exif                                                                   │
│                                                                                                  │
│   243 │   │   """                                                                                │
│   244 │   │   exiftool = ExifTool(filepath=photo_path, exiftool=self.exiftool_path)              │
│   245 │   │   exif = exiftool.asdict()                                                           │
│ ❱ 246 │   │   return get_exif_date_time_offset(                                                  │
│   247 │   │   │   exif, use_file_modify_date=use_file_modify_date                                │
│   248 │   │   )                                                                                  │
│   249                                                                                            │
│                                                                                                  │
│ /opt/homebrew/lib/python3.10/site-packages/osxphotos/exif_datetime_updater.py:325 in             │
│ get_exif_date_time_offset                                                                        │
│                                                                                                  │
│   322 │   │   │   │   dt = f"{matched.group(1)} 00:00:00"                                        │
│   323 │   │   │   │   default_time = True                                                        │
│   324 │                                                                                          │
│ ❱ 325 │   offset_seconds = exif_offset_to_seconds(offset) if offset else None                    │
│   326 │                                                                                          │
│   327 │   if dt:                                                                                 │
│   328 │   │   if offset:                                                                         │
│                                                                                                  │
│ /opt/homebrew/lib/python3.10/site-packages/osxphotos/exif_datetime_updater.py:45 in              │
│ exif_offset_to_seconds                                                                           │
│                                                                                                  │
│    42 def exif_offset_to_seconds(offset: str) -> int:                                            │
│    43 │   """Convert timezone offset from UTC in exiftool format (+/-hh:mm) to seconds"""        │
│    44 │   sign = 1 if offset[0] == "+" else -1                                                   │
│ ❱  45 │   hours, minutes = offset[1:].split(":")                                                 │
│    46 │   return sign * (int(hours) * 3600 + int(minutes) * 60)                                  │
│    47                                                                                            │
│    48                                                                                            │
╰──────────────────────────────────────────────────────────────────────────────────────────────────╯
ValueError: not enough values to unpack (expected 2, got 1)
```

I determined this to be due to the value of OffsetTimeOriginal being "Z" for Zulu time or UTC+0. I'm not sure if this is standard or not, but it was set by many iPhone pictures and I wanted to know if the following change was a valid fix?