### PR TITLE
Use "QuickTime:ContentCreateDate"

### DIFF
--- a/osxphotos/exif_datetime_updater.py
+++ b/osxphotos/exif_datetime_updater.py
@@ -285,6 +285,7 @@ def get_exif_date_time_offset(
     time_fields = [
         "EXIF:DateTimeOriginal",
         "EXIF:CreateDate",
+        "QuickTime:ContentCreateDate",
         "QuickTime:CreationDate",
         "QuickTime:CreateDate",
         "IPTC:DateCreated",


### PR DESCRIPTION
Hello! 

I recently had a bunch of `m4v` files categorized with the wrong date. Thanks to your earlier tip, I was able to fix that by using `QuickTime:ContentCreateDate`. All the other fields were wrong, I am not sure why.

I don't think I am the only person experiencing this: 
https://gist.github.com/jhubble/432a1ad713b0a9e0dee6ea78b431b579 
https://exiftool.org/forum/index.php?topic=7904.0
https://github.com/photoprism/photoprism/issues/1691#issuecomment-956477211

I suggest having it on the list, and I suggest having it prioritized.

Thanks!