### PR TITLE
Port to non-MacOS platforms

### DIFF
--- a/osxphotos/__init__.py
+++ b/osxphotos/__init__.py
@@ -16,7 +16,6 @@ from .momentinfo import MomentInfo
 from .personinfo import PersonInfo
 from .photoexporter import ExportOptions, ExportResults, PhotoExporter
 from .photoinfo import PhotoInfo
-from .photosalbum import PhotosAlbum, PhotosAlbumPhotoScript
 from .photosdb import PhotosDB
 from .photosdb._photosdb_process_comments import CommentInfo, LikeInfo
 from .phototables import PhotoTables
@@ -25,6 +24,10 @@ from .placeinfo import PlaceInfo
 from .queryoptions import QueryOptions
 from .scoreinfo import ScoreInfo
 from .searchinfo import SearchInfo
+from .utils import is_macos
+
+if is_macos:
+    from .photosalbum import PhotosAlbum, PhotosAlbumPhotoScript
 
 # configure logging; every module in osxphotos should use this logger
 logging.basicConfig(

--- a/osxphotos/cli/__init__.py
+++ b/osxphotos/cli/__init__.py
@@ -75,6 +75,7 @@ from .list import _list_libraries, list_libraries
 from .orphans import orphans
 from .persons import persons
 from .places import places
+from .query import query
 from .repl import repl
 from .snap_diff import diff, snap
 from .theme import theme
@@ -86,7 +87,6 @@ if is_macos:
     from .batch_edit import batch_edit
     from .import_cli import import_cli
     from .photo_inspect import photo_inspect
-    from .query import query
     from .show_command import show
     from .sync import sync
     from .timewarp import timewarp

--- a/osxphotos/cli/__init__.py
+++ b/osxphotos/cli/__init__.py
@@ -5,6 +5,7 @@ import sys
 from rich import print
 from rich.traceback import install as install_traceback
 
+from osxphotos.utils import is_macos
 from osxphotos.debug import (
     debug_breakpoint,
     debug_watch,
@@ -44,9 +45,7 @@ if args.get("--debug", False):
     print("Debugging enabled", file=sys.stderr)
 
 from .about import about
-from .add_locations import add_locations
 from .albums import albums
-from .batch_edit import batch_edit
 from .cli import cli_main
 from .cli_commands import (
     abort,
@@ -67,7 +66,6 @@ from .export import export
 from .exportdb import exportdb
 from .grep import grep
 from .help import help
-from .import_cli import import_cli
 from .info import info
 from .install_uninstall_run import install, run, uninstall
 from .keywords import keywords
@@ -76,18 +74,23 @@ from .labels import labels
 from .list import _list_libraries, list_libraries
 from .orphans import orphans
 from .persons import persons
-from .photo_inspect import photo_inspect
 from .places import places
-from .query import query
 from .repl import repl
-from .show_command import show
 from .snap_diff import diff, snap
-from .sync import sync
 from .theme import theme
-from .timewarp import timewarp
 from .tutorial import tutorial
-from .uuid import uuid
 from .version import version
+
+if is_macos:
+    from .add_locations import add_locations
+    from .batch_edit import batch_edit
+    from .import_cli import import_cli
+    from .photo_inspect import photo_inspect
+    from .query import query
+    from .show_command import show
+    from .sync import sync
+    from .timewarp import timewarp
+    from .uuid import uuid
 
 install_traceback()
 

--- a/osxphotos/cli/add_locations.py
+++ b/osxphotos/cli/add_locations.py
@@ -5,11 +5,10 @@ from __future__ import annotations
 import datetime
 
 import click
-import photoscript
 
 import osxphotos
 from osxphotos.queryoptions import IncompatibleQueryOptions, query_options_from_kwargs
-from osxphotos.utils import pluralize
+from osxphotos.utils import assert_macos, pluralize
 
 from .cli_params import QUERY_OPTIONS, THEME_OPTION, TIMESTAMP_OPTION, VERBOSE_OPTION
 from .click_rich_echo import rich_click_echo as echo
@@ -17,6 +16,10 @@ from .click_rich_echo import rich_echo_error as echo_error
 from .param_types import TimeOffset
 from .rich_progress import rich_progress
 from .verbose import get_verbose_console, verbose_print
+
+assert_macos()
+
+import photoscript
 
 
 def get_location(

--- a/osxphotos/cli/batch_edit.py
+++ b/osxphotos/cli/batch_edit.py
@@ -9,11 +9,15 @@ import json
 import sys
 
 import click
-import photoscript
 
 import osxphotos
 from osxphotos.phototemplate import RenderOptions
 from osxphotos.sqlitekvstore import SQLiteKVStore
+from osxphotos.utils import assert_macos
+
+assert_macos()
+
+import photoscript
 
 from .cli_commands import echo, echo_error, selection_command, verbose
 from .kvstore import kvstore

--- a/osxphotos/cli/cli.py
+++ b/osxphotos/cli/cli.py
@@ -31,6 +31,7 @@ from .list import list_libraries
 from .orphans import orphans
 from .persons import persons
 from .places import places
+from .query import query
 from .repl import repl
 from .snap_diff import diff, snap
 from .theme import theme
@@ -42,7 +43,6 @@ if is_macos:
     from .batch_edit import batch_edit
     from .import_cli import import_cli
     from .photo_inspect import photo_inspect
-    from .query import query
     from .show_command import show
     from .sync import sync
     from .timewarp import timewarp
@@ -129,6 +129,7 @@ commands = [
     orphans,
     persons,
     places,
+    query,
     repl,
     run,
     snap,
@@ -144,7 +145,6 @@ if is_macos:
         batch_edit,
         import_cli,
         photo_inspect,
-        query,
         show,
         sync,
         timewarp,

--- a/osxphotos/cli/cli.py
+++ b/osxphotos/cli/cli.py
@@ -9,11 +9,10 @@ import click
 
 from osxphotos._constants import PROFILE_SORT_KEYS
 from osxphotos._version import __version__
+from osxphotos.utils import is_macos
 
 from .about import about
-from .add_locations import add_locations
 from .albums import albums
-from .batch_edit import batch_edit
 from .cli_params import DB_OPTION, DEBUG_OPTIONS, JSON_OPTION, VERSION_OPTION
 from .common import OSXPHOTOS_HIDDEN
 from .debug_dump import debug_dump
@@ -24,7 +23,6 @@ from .export import export
 from .exportdb import exportdb
 from .grep import grep
 from .help import help
-from .import_cli import import_cli
 from .info import info
 from .install_uninstall_run import install, run, uninstall
 from .keywords import keywords
@@ -32,18 +30,23 @@ from .labels import labels
 from .list import list_libraries
 from .orphans import orphans
 from .persons import persons
-from .photo_inspect import photo_inspect
 from .places import places
-from .query import query
 from .repl import repl
-from .show_command import show
 from .snap_diff import diff, snap
-from .sync import sync
 from .theme import theme
-from .timewarp import timewarp
 from .tutorial import tutorial
-from .uuid import uuid
 from .version import version
+
+if is_macos:
+    from .add_locations import add_locations
+    from .batch_edit import batch_edit
+    from .import_cli import import_cli
+    from .photo_inspect import photo_inspect
+    from .query import query
+    from .show_command import show
+    from .sync import sync
+    from .timewarp import timewarp
+    from .uuid import uuid
 
 
 # Click CLI object & context settings
@@ -106,11 +109,9 @@ def cli_main(ctx, db, json_, profile, profile_sort, **kwargs):
 
 
 # install CLI commands
-for command in [
+commands = [
     about,
-    add_locations,
     albums,
-    batch_edit,
     debug_dump,
     diff,
     docs_command,
@@ -120,7 +121,6 @@ for command in [
     exportdb,
     grep,
     help,
-    import_cli,
     info,
     install,
     keywords,
@@ -128,19 +128,28 @@ for command in [
     list_libraries,
     orphans,
     persons,
-    photo_inspect,
     places,
-    query,
     repl,
     run,
-    show,
     snap,
-    sync,
     theme,
-    timewarp,
     tutorial,
     uninstall,
-    uuid,
     version,
-]:
+]
+
+if is_macos:
+    commands += [
+        add_locations,
+        batch_edit,
+        import_cli,
+        photo_inspect,
+        query,
+        show,
+        sync,
+        timewarp,
+        uuid,
+    ]
+
+for command in commands:
     cli_main.add_command(command)

--- a/osxphotos/cli/cli_params.py
+++ b/osxphotos/cli/cli_params.py
@@ -8,6 +8,8 @@ from typing import Any, Callable
 import click
 import contextlib
 from textwrap import dedent
+
+from ..utils import is_macos
 from .common import OSXPHOTOS_HIDDEN, print_version
 from .param_types import *
 
@@ -641,6 +643,9 @@ _QUERY_PARAMETERS_DICT = {
         + "See https://github.com/RhetTbull/osxphotos/blob/master/examples/query_function.py for example of how to use this option.",
     ),
 }
+
+if not is_macos:
+    del _QUERY_PARAMETERS_DICT["--selected"]
 
 
 def QUERY_OPTIONS(

--- a/osxphotos/cli/darkmode.py
+++ b/osxphotos/cli/darkmode.py
@@ -1,19 +1,34 @@
-"""Detect dark mode on MacOS >= 10.14"""
+"""Detect dark mode on MacOS >= 10.14 or fake it elsewhere"""
 
-import objc
-import Foundation
-
-
-def theme():
-    with objc.autorelease_pool():
-        user_defaults = Foundation.NSUserDefaults.standardUserDefaults()
-        system_theme = user_defaults.stringForKey_("AppleInterfaceStyle")
-        return "dark" if system_theme == "Dark" else "light"
+from osxphotos.utils import is_macos
 
 
-def is_dark_mode():
-    return theme() == "dark"
+if is_macos:
+    import objc
+    import Foundation
 
 
-def is_light_mode():
-    return theme() == "light"
+    def theme():
+        with objc.autorelease_pool():
+            user_defaults = Foundation.NSUserDefaults.standardUserDefaults()
+            system_theme = user_defaults.stringForKey_("AppleInterfaceStyle")
+            return "dark" if system_theme == "Dark" else "light"
+
+
+    def is_dark_mode():
+        return theme() == "dark"
+
+
+    def is_light_mode():
+        return theme() == "light"
+else:
+    def theme():
+        return "light"
+
+
+    def is_dark_mode():
+        return theme() == "dark"
+
+
+    def is_light_mode():
+        return theme() == "light"

--- a/osxphotos/cli/export.py
+++ b/osxphotos/cli/export.py
@@ -855,7 +855,6 @@ def export(
     retry,
     save_config,
     screenshot,
-    selected,
     selfie,
     shared,
     sidecar,
@@ -887,6 +886,7 @@ def export(
     verbose_flag,
     xattr_template,
     year,
+    selected=False,  # Isn't provided on unsupported platforms
     # debug,  # debug, watch, breakpoint handled in cli/__init__.py
     # watch,
     # breakpoint,

--- a/osxphotos/cli/import_cli.py
+++ b/osxphotos/cli/import_cli.py
@@ -20,7 +20,6 @@ from textwrap import dedent
 from typing import Callable, Dict, List, Optional, Tuple, Union
 
 import click
-from photoscript import Photo, PhotosLibrary
 from rich.console import Console
 from rich.markdown import Markdown
 from strpdatetime import strpdatetime
@@ -43,7 +42,11 @@ from osxphotos.photoinfo import PhotoInfoNone
 from osxphotos.photosalbum import PhotosAlbumPhotoScript
 from osxphotos.phototemplate import PhotoTemplate, RenderOptions
 from osxphotos.sqlitekvstore import SQLiteKVStore
-from osxphotos.utils import pluralize
+from osxphotos.utils import assert_macos, pluralize
+
+assert_macos()
+
+from photoscript import Photo, PhotosLibrary
 
 from .cli_params import THEME_OPTION
 from .click_rich_echo import rich_click_echo, rich_echo_error

--- a/osxphotos/cli/photo_inspect.py
+++ b/osxphotos/cli/photo_inspect.py
@@ -13,8 +13,6 @@ from typing import Generator, List, Optional, Tuple
 
 import bitmath
 import click
-from applescript import ScriptError
-from photoscript import PhotosLibrary
 from rich.console import Console
 from rich.layout import Layout
 from rich.live import Live
@@ -23,8 +21,14 @@ from rich.panel import Panel
 from osxphotos import PhotoInfo, PhotosDB
 from osxphotos._constants import _UNKNOWN_PERSON, search_category_factory
 from osxphotos.rich_utils import add_rich_markup_tag
+from osxphotos.utils import assert_macos, dd_to_dms_str
+
+assert_macos()
+
+from applescript import ScriptError
+from photoscript import PhotosLibrary
+
 from osxphotos.text_detection import detect_text as detect_text_in_photo
-from osxphotos.utils import dd_to_dms_str
 
 from .cli_params import DB_OPTION, THEME_OPTION
 from .color_themes import get_theme

--- a/osxphotos/cli/query.py
+++ b/osxphotos/cli/query.py
@@ -34,7 +34,7 @@ from .verbose import get_verbose_console
 
 MACOS_OPTIONS = make_click_option_decorator(*[
     click.Option(
-        "--add-to-album",
+        ["--add-to-album"],
         metavar="ALBUM",
         help="Add all photos from query to album ALBUM in Photos. Album ALBUM will be created "
         "if it doesn't exist.  All photos in the query results will be added to this album. "

--- a/osxphotos/cli/query.py
+++ b/osxphotos/cli/query.py
@@ -9,9 +9,13 @@ from osxphotos.cli.click_rich_echo import (
     set_rich_theme,
 )
 from osxphotos.debug import set_debug
-from osxphotos.photosalbum import PhotosAlbum
 from osxphotos.phototemplate import RenderOptions
 from osxphotos.queryoptions import query_options_from_kwargs
+from osxphotos.utils import assert_macos
+
+assert_macos()
+
+from osxphotos.photosalbum import PhotosAlbum
 
 from .cli_params import (
     DB_ARGUMENT,

--- a/osxphotos/cli/repl.py
+++ b/osxphotos/cli/repl.py
@@ -10,8 +10,6 @@ import time
 from typing import List
 
 import click
-import photoscript
-from applescript import ScriptError
 from rich import pretty, print
 
 import osxphotos
@@ -25,6 +23,11 @@ from osxphotos.queryoptions import (
     QueryOptions,
     query_options_from_kwargs,
 )
+from osxphotos.utils import assert_macos, is_macos
+
+if is_macos:
+    import photoscript
+    from applescript import ScriptError
 
 from .cli_params import DB_ARGUMENT, DB_OPTION, DELETED_OPTIONS, QUERY_OPTIONS
 from .common import get_photos_db
@@ -55,7 +58,8 @@ def repl(ctx, cli_obj, db, emacs, beta, **kwargs):
     import logging
 
     from objexplore import explore
-    from photoscript import Album, Photo, PhotosLibrary
+    if is_macos:
+        from photoscript import Album, Photo, PhotosLibrary
     from rich import inspect as _inspect
 
     from osxphotos import ExifTool, PhotoInfo, PhotosDB
@@ -194,6 +198,7 @@ def _get_selected(photosdb):
     """get list of PhotoInfo objects for photos selected in Photos"""
 
     def get_selected():
+        assert_macos()
         try:
             selected = photoscript.PhotosLibrary().selection
         except ScriptError as e:
@@ -209,6 +214,7 @@ def _get_selected(photosdb):
 
 
 def _spotlight_photo(photo: PhotoInfo):
+    assert_macos()
     photo_ = photoscript.Photo(photo.uuid)
     photo_.spotlight()
 

--- a/osxphotos/cli/show_command.py
+++ b/osxphotos/cli/show_command.py
@@ -7,12 +7,15 @@ import click
 
 from osxphotos._constants import UUID_PATTERN
 from osxphotos.export_db_utils import get_uuid_for_filepath
+from osxphotos.photosdb.photosdb_utils import get_photos_library_version
+from osxphotos.utils import get_last_library_path, assert_macos
+
+assert_macos()
+
 from osxphotos.photoscript_utils import (
     photoscript_object_from_name,
     photoscript_object_from_uuid,
 )
-from osxphotos.photosdb.photosdb_utils import get_photos_library_version
-from osxphotos.utils import get_last_library_path
 
 from .cli_commands import echo, echo_error
 from .cli_params import DB_OPTION

--- a/osxphotos/cli/sync.py
+++ b/osxphotos/cli/sync.py
@@ -9,7 +9,6 @@ import pathlib
 from typing import Any, Callable, Literal
 
 import click
-import photoscript
 
 from osxphotos import PhotoInfo, PhotosDB, __version__
 from osxphotos.photoinfo import PhotoInfoNone
@@ -22,7 +21,11 @@ from osxphotos.queryoptions import (
     query_options_from_kwargs,
 )
 from osxphotos.sqlitekvstore import SQLiteKVStore
-from osxphotos.utils import pluralize
+from osxphotos.utils import assert_macos, pluralize
+
+assert_macos()
+
+import photoscript
 
 from .cli_params import (
     DB_OPTION,

--- a/osxphotos/cli/timewarp.py
+++ b/osxphotos/cli/timewarp.py
@@ -7,7 +7,6 @@ from functools import partial
 from textwrap import dedent
 
 import click
-from photoscript import PhotosLibrary
 from rich.console import Console
 
 from osxphotos._constants import APP_NAME
@@ -25,9 +24,13 @@ from osxphotos.photodates import (
     update_photo_from_function,
     update_photo_time_for_new_timezone,
 )
-from osxphotos.photosalbum import PhotosAlbumPhotoScript
 from osxphotos.phototz import PhotoTimeZone, PhotoTimeZoneUpdater
-from osxphotos.utils import noop, pluralize
+from osxphotos.utils import assert_macos, noop, pluralize
+
+assert_macos()
+
+from photoscript import PhotosLibrary
+from osxphotos.photosalbum import PhotosAlbumPhotoScript
 
 from .cli_params import THEME_OPTION, TIMESTAMP_OPTION, VERBOSE_OPTION
 from .click_rich_echo import rich_click_echo as echo

--- a/osxphotos/cli/uuid.py
+++ b/osxphotos/cli/uuid.py
@@ -1,6 +1,11 @@
 """uuid command for osxphotos CLI"""
 
 import click
+
+from osxphotos.utils import assert_macos
+
+assert_macos()
+
 import photoscript
 
 

--- a/osxphotos/compare_exif.py
+++ b/osxphotos/compare_exif.py
@@ -5,12 +5,15 @@ from typing import Callable, List, Optional, Tuple
 
 from osxphotos import PhotosDB
 from osxphotos.exiftool import ExifTool
-from photoscript import Photo
 
 from .datetime_utils import datetime_naive_to_local, datetime_to_new_tz
+from .utils import assert_macos, noop
+
+assert_macos()
+
+from photoscript import Photo
 from .exif_datetime_updater import get_exif_date_time_offset
 from .phototz import PhotoTimeZone
-from .utils import noop
 
 ExifDiff = namedtuple(
     "ExifDiff",

--- a/osxphotos/imageconverter.py
+++ b/osxphotos/imageconverter.py
@@ -5,15 +5,19 @@
 # reference: https://stackoverflow.com/questions/59330149/coreimage-ciimage-write-jpg-is-shifting-colors-macos/59334308#59334308
 
 import pathlib
-
-import objc
-import Metal
-import Quartz
-from Cocoa import NSURL
-from Foundation import NSDictionary
+import sys
 
 # needed to capture system-level stderr
 from wurlitzer import pipes
+
+from .utils import is_macos
+
+if is_macos:
+    import objc
+    import Metal
+    import Quartz
+    from Cocoa import NSURL
+    from Foundation import NSDictionary
 
 __all__ = ["ImageConversionError", "ImageConverter"]
 

--- a/osxphotos/photoinfo.py
+++ b/osxphotos/photoinfo.py
@@ -20,7 +20,6 @@ from types import SimpleNamespace
 from typing import Any, Dict, Optional
 
 import yaml
-from osxmetadata import OSXMetaData
 
 import osxphotos
 
@@ -65,9 +64,12 @@ from .placeinfo import PlaceInfo4, PlaceInfo5
 from .query_builder import get_query
 from .scoreinfo import ScoreInfo
 from .searchinfo import SearchInfo
-from .text_detection import detect_text
 from .uti import get_preferred_uti_extension, get_uti_for_extension
-from .utils import _get_resource_loc, hexdigest, list_directory
+from .utils import _get_resource_loc, assert_macos, is_macos, hexdigest, list_directory
+
+if is_macos:
+    from osxmetadata import OSXMetaData
+    from .text_detection import detect_text
 
 __all__ = ["PhotoInfo", "PhotoInfoNone", "frozen_photoinfo_factory"]
 
@@ -1461,6 +1463,8 @@ class PhotoInfo:
 
     def _detected_text(self):
         """detect text in photo, either from cached extended attribute or by attempting text detection"""
+        assert_macos()
+
         path = (
             self.path_edited if self.hasadjustments and self.path_edited else self.path
         )

--- a/osxphotos/photokit.py
+++ b/osxphotos/photokit.py
@@ -19,8 +19,11 @@
 
 import copy
 import pathlib
+import sys
 import threading
 import time
+
+assert(sys.platform == "darwin")
 
 import AVFoundation
 import CoreServices

--- a/osxphotos/photosalbum.py
+++ b/osxphotos/photosalbum.py
@@ -2,12 +2,15 @@
 
 from typing import List, Optional
 
-import photoscript
 from more_itertools import chunked
-from photoscript import Album, Folder, Photo, PhotosLibrary
 
 from .photoinfo import PhotoInfo
-from .utils import noop, pluralize
+from .utils import assert_macos, noop, pluralize
+
+assert_macos()
+
+import photoscript
+from photoscript import Album, Folder, Photo, PhotosLibrary
 
 __all__ = ["PhotosAlbum", "PhotosAlbumPhotoScript"]
 

--- a/osxphotos/photoscript_utils.py
+++ b/osxphotos/photoscript_utils.py
@@ -4,6 +4,10 @@ from __future__ import annotations
 
 import sqlite3
 
+from .utils import assert_macos
+
+assert_macos()
+
 import photoscript
 
 from ._constants import _DB_TABLE_NAMES, _PHOTOS_5_ALBUM_KIND, _PHOTOS_5_FOLDER_KIND

--- a/osxphotos/photosdb/photosdb.py
+++ b/osxphotos/photosdb/photosdb.py
@@ -21,7 +21,6 @@ from typing import Any, List, Optional
 from unicodedata import normalize
 
 import bitmath
-import photoscript
 from rich import print
 
 from .._constants import (
@@ -62,12 +61,16 @@ from ..rich_utils import add_rich_markup_tag
 from ..sqlite_utils import sqlite_db_is_locked, sqlite_open_ro
 from ..utils import (
     _check_file_exists,
+    is_macos,
     get_macos_version,
     get_last_library_path,
     noop,
     normalize_unicode,
 )
 from .photosdb_utils import get_db_model_version, get_db_version
+
+if is_macos:
+    import photoscript
 
 logger = logging.getLogger("osxphotos")
 
@@ -118,8 +121,8 @@ class PhotosDB:
 
         # Check OS version
         system = platform.system()
-        (ver, major, _) = get_macos_version()
-        if system != "Darwin" or ((ver, major) not in _TESTED_OS_VERSIONS):
+        (ver, major, _) = get_macos_version() if is_macos else (None, None, None)
+        if system == "Darwin" and ((ver, major) not in _TESTED_OS_VERSIONS):
             logging.warning(
                 f"WARNING: This module has only been tested with macOS versions "
                 f"[{', '.join(f'{v}.{m}' for (v, m) in _TESTED_OS_VERSIONS)}]: "

--- a/osxphotos/phototemplate.py
+++ b/osxphotos/phototemplate.py
@@ -21,7 +21,6 @@ from ._version import __version__
 from .datetime_formatter import DateTimeFormatter
 from .exiftool import ExifToolCaching
 from .path_utils import sanitize_dirname, sanitize_filename, sanitize_pathpart
-from .text_detection import detect_text
 from .utils import expand_and_validate_filepath, load_function, uuid_to_shortuuid
 
 __all__ = [

--- a/osxphotos/text_detection.py
+++ b/osxphotos/text_detection.py
@@ -1,7 +1,12 @@
 """ Use Apple's Vision Framework via PyObjC to perform text detection on images (macOS 10.15+ only) """
 
 import logging
+import sys
 from typing import List, Optional
+
+from .utils import assert_macos, get_macos_version
+
+assert_macos()
 
 import objc
 import Quartz
@@ -10,8 +15,6 @@ from Foundation import NSDictionary
 
 # needed to capture system-level stderr
 from wurlitzer import pipes
-
-from .utils import get_macos_version
 
 __all__ = ["detect_text", "make_request_handler"]
 

--- a/osxphotos/timezones.py
+++ b/osxphotos/timezones.py
@@ -2,13 +2,7 @@
 
 from typing import Union
 
-import Foundation
-import objc
-
-
-def known_timezone_names():
-    """Get list of valid timezones on macOS"""
-    return Foundation.NSTimeZone.knownTimeZoneNames()
+from .utils import is_macos
 
 
 def format_offset_time(offset: int) -> str:
@@ -19,43 +13,107 @@ def format_offset_time(offset: int) -> str:
     return f"{sign}{hours:02d}:{minutes:02d}"
 
 
-class Timezone:
-    """Create Timezone object from either name (str) or offset from GMT (int)"""
+if is_macos:
+    import Foundation
+    import objc
 
-    def __init__(self, tz: Union[str, int]):
-        with objc.autorelease_pool():
+
+    def known_timezone_names():
+        """Get list of valid timezones on macOS"""
+        return Foundation.NSTimeZone.knownTimeZoneNames()
+
+
+    class Timezone:
+        """Create Timezone object from either name (str) or offset from GMT (int)"""
+
+        def __init__(self, tz: Union[str, int]):
+            with objc.autorelease_pool():
+                if isinstance(tz, str):
+                    self.timezone = Foundation.NSTimeZone.timeZoneWithName_(tz)
+                    self._name = tz
+                elif isinstance(tz, int):
+                    self.timezone = Foundation.NSTimeZone.timeZoneForSecondsFromGMT_(tz)
+                    self._name = self.timezone.name()
+                else:
+                    raise TypeError("Timezone must be a string or an int")
+
+        @property
+        def name(self) -> str:
+            return self._name
+
+        @property
+        def offset(self) -> int:
+            return self.timezone.secondsFromGMT()
+
+        @property
+        def offset_str(self) -> str:
+            return format_offset_time(self.offset)
+
+        @property
+        def abbreviation(self) -> str:
+            return self.timezone.abbreviation()
+
+        def __str__(self):
+            return self.name
+
+        def __repr__(self):
+            return self.name
+
+        def __eq__(self, other):
+            if isinstance(other, Timezone):
+                return self.timezone == other.timezone
+            return False
+else:
+    import zoneinfo
+    from datetime import datetime
+
+    def known_timezone_names():
+        """Get list of valid timezones"""
+        return zoneinfo.available_timezones()
+
+
+    class Timezone:
+        """Create Timezone object from either name (str) or offset from GMT (int)"""
+
+        def __init__(self, tz: Union[str, int]):
             if isinstance(tz, str):
-                self.timezone = Foundation.NSTimeZone.timeZoneWithName_(tz)
+                self.timezone = zoneinfo.ZoneInfo(tz)
                 self._name = tz
             elif isinstance(tz, int):
-                self.timezone = Foundation.NSTimeZone.timeZoneForSecondsFromGMT_(tz)
-                self._name = self.timezone.name()
+                if tz > 0:
+                    name = f"Etc/GMT+{tz // 3600}"
+                else:
+                    name = f"Etc/GMT-{-tz // 3600}"
+                self.timezone = zoneinfo.ZoneInfo(name)
+                self._name = self.timezone.key
             else:
                 raise TypeError("Timezone must be a string or an int")
 
-    @property
-    def name(self) -> str:
-        return self._name
+        @property
+        def name(self) -> str:
+            return self._name
 
-    @property
-    def offset(self) -> int:
-        return self.timezone.secondsFromGMT()
+        @property
+        def offset(self) -> int:
+            td = self.timezone.utcoffset(datetime.now())
+            assert td
+            return int(td.total_seconds())
 
-    @property
-    def offset_str(self) -> str:
-        return format_offset_time(self.offset)
+        @property
+        def offset_str(self) -> str:
+            return format_offset_time(self.offset)
 
-    @property
-    def abbreviation(self) -> str:
-        return self.timezone.abbreviation()
+        @property
+        def abbreviation(self) -> str:
+            return self.timezone.key
 
-    def __str__(self):
-        return self.name
+        def __str__(self):
+            return self.name
 
-    def __repr__(self):
-        return self.name
+        def __repr__(self):
+            return self.name
 
-    def __eq__(self, other):
-        if isinstance(other, Timezone):
-            return self.timezone == other.timezone
-        return False
+        def __eq__(self, other):
+            if isinstance(other, Timezone):
+                return self.timezone == other.timezone
+            return False

--- a/osxphotos/utils.py
+++ b/osxphotos/utils.py
@@ -282,10 +282,11 @@ def list_photo_libraries():
 T = TypeVar("T", bound=Union[str, pathlib.Path])
 def normalize_fs_path(path: T) -> T:
     """Normalize filesystem paths with unicode in them"""
+    form = "NFD" if is_macos else "NFC"
     if isinstance(path, pathlib.Path):
-        return pathlib.Path(unicodedata.normalize("NFC", str(path)))
+        return pathlib.Path(unicodedata.normalize(form, str(path)))
     else:
-        return unicodedata.normalize("NFC", path)
+        return unicodedata.normalize(form, path)
 
 
 # def findfiles(pattern, path):

--- a/tests/locale_util.py
+++ b/tests/locale_util.py
@@ -1,5 +1,6 @@
 """ Helpers for running locale-dependent tests """
 
+import contextlib
 import locale
 
 import pytest

--- a/tests/locale_util.py
+++ b/tests/locale_util.py
@@ -7,10 +7,9 @@ import pytest
 
 def setlocale(typ, name):
     try:
-        try:
+        with contextlib.suppress(Exception):
             locale.setlocale(typ, name)
-        except: pass
         # On Linux UTF-8 locales are separate
-        locale.setlocale(typ, name + ".UTF-8")
+        locale.setlocale(typ, f"{name}.UTF-8")
     except locale.Error:
         pytest.skip(f"Locale {name} not available")

--- a/tests/locale_util.py
+++ b/tests/locale_util.py
@@ -1,0 +1,16 @@
+""" Helpers for running locale-dependent tests """
+
+import locale
+
+import pytest
+
+
+def setlocale(typ, name):
+    try:
+        try:
+            locale.setlocale(typ, name)
+        except: pass
+        # On Linux UTF-8 locales are separate
+        locale.setlocale(typ, name + ".UTF-8")
+    except locale.Error:
+        pytest.skip(f"Locale {name} not available")

--- a/tests/test_catalina_10_15_7.py
+++ b/tests/test_catalina_10_15_7.py
@@ -15,9 +15,9 @@ import pytest
 import osxphotos
 from osxphotos._constants import _UNKNOWN_PERSON
 from osxphotos.photoexporter import PhotoExporter
-from osxphotos.utils import get_macos_version
+from osxphotos.utils import is_macos, get_macos_version
 
-OS_VERSION = get_macos_version()
+OS_VERSION = get_macos_version() if is_macos else (None, None, None)
 SKIP_TEST = "OSXPHOTOS_TEST_EXPORT" not in os.environ or OS_VERSION[1] != "15"
 PHOTOS_DB_LOCAL = os.path.expanduser("~/Pictures/Photos Library.photoslibrary")
 
@@ -1448,6 +1448,7 @@ def test_multi_uuid(photosdb):
     assert len(photos) == 2
 
 
+@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_detected_text(photosdb):
     """test PhotoInfo.detected_text"""
     for uuid, expected_text in UUID_DETECTED_TEXT.items():

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -43,6 +43,10 @@ if is_macos:
 from .conftest import copy_photos_library_to_path
 from .locale_util import setlocale
 
+def _normalize_fs_paths(paths):
+    """Small helper to prepare path strings for test"""
+    return [normalize_fs_path(p) for p in paths]
+
 CLI_PHOTOS_DB = "tests/Test-10.15.7.photoslibrary"
 LIVE_PHOTOS_DB = "tests/Test-Cloud-10.15.1.photoslibrary"
 RAW_PHOTOS_DB = "tests/Test-RAW-10.15.1.photoslibrary"
@@ -69,18 +73,18 @@ SKIP_UUID_FILE = "tests/skip_uuid_from_file.txt"
 
 CLI_OUTPUT_QUERY_UUID = '[{"uuid": "D79B8D77-BFFC-460B-9312-034F2877D35B", "filename": "D79B8D77-BFFC-460B-9312-034F2877D35B.jpeg", "original_filename": "Pumkins2.jpg", "date": "2018-09-28T16:07:07-04:00", "description": "Girl holding pumpkin", "title": "I found one!", "keywords": ["Kids"], "albums": ["Pumpkin Farm", "Test Album", "Multi Keyword"], "persons": ["Katie"], "path": "/tests/Test-10.15.7.photoslibrary/originals/D/D79B8D77-BFFC-460B-9312-034F2877D35B.jpeg", "ismissing": false, "hasadjustments": false, "external_edit": false, "favorite": false, "hidden": false, "latitude": 41.256566, "longitude": -95.940257, "path_edited": null, "shared": false, "isphoto": true, "ismovie": false, "uti": "public.jpeg", "burst": false, "live_photo": false, "path_live_photo": null, "iscloudasset": false, "incloud": null}]'
 
-CLI_EXPORT_FILENAMES = [
+CLI_EXPORT_FILENAMES = _normalize_fs_paths([
     "[2020-08-29] AAF035 (1).jpg",
     "[2020-08-29] AAF035 (2).jpg",
     "[2020-08-29] AAF035 (3).jpg",
     "[2020-08-29] AAF035.jpg",
     "DSC03584.dng",
-    "Frítest (1).jpg",
-    "Frítest (2).jpg",
-    "Frítest (3).jpg",
-    "Frítest_edited (1).jpeg",
-    "Frítest_edited.jpeg",
-    "Frítest.jpg",
+    "Frítest (1).jpg",
+    "Frítest (2).jpg",
+    "Frítest (3).jpg",
+    "Frítest_edited (1).jpeg",
+    "Frítest_edited.jpeg",
+    "Frítest.jpg",
     "IMG_1693.tif",
     "IMG_1994.cr2",
     "IMG_1994.JPG",
@@ -103,14 +107,14 @@ CLI_EXPORT_FILENAMES = [
     "wedding.jpg",
     "winebottle (1).jpeg",
     "winebottle.jpeg",
-]
+])
 
 
-CLI_EXPORT_FILENAMES_DRY_RUN = [
+CLI_EXPORT_FILENAMES_DRY_RUN = _normalize_fs_paths([
     "[2020-08-29] AAF035.jpg",
     "DSC03584.dng",
-    "Frítest_edited.jpeg",
-    "Frítest.jpg",
+    "Frítest_edited.jpeg",
+    "Frítest.jpg",
     "IMG_1693.tif",
     "IMG_1994.cr2",
     "IMG_1994.JPG",
@@ -133,15 +137,25 @@ CLI_EXPORT_FILENAMES_DRY_RUN = [
     "wedding.jpg",
     "winebottle.jpeg",
     "winebottle.jpeg",
-]
+])
 
-CLI_EXPORT_IGNORE_SIGNATURE_FILENAMES = ["Tulips.jpg", "wedding.jpg"]
+CLI_EXPORT_IGNORE_SIGNATURE_FILENAMES = _normalize_fs_paths([
+    "Tulips.jpg",
+    "wedding.jpg"
+])
 
-CLI_EXPORT_FILENAMES_ALBUM = ["Pumkins1.jpg", "Pumkins2.jpg", "Pumpkins3.jpg"]
+CLI_EXPORT_FILENAMES_ALBUM = _normalize_fs_paths([
+    "Pumkins1.jpg",
+    "Pumkins2.jpg",
+    "Pumpkins3.jpg"
+])
 
-CLI_EXPORT_FILENAMES_ALBUM_UNICODE = ["IMG_4547.jpg"]
+CLI_EXPORT_FILENAMES_ALBUM_UNICODE = _normalize_fs_paths(["IMG_4547.jpg"])
 
-CLI_EXPORT_FILENAMES_DELETED_TWIN = ["wedding.jpg", "wedding_edited.jpeg"]
+CLI_EXPORT_FILENAMES_DELETED_TWIN = _normalize_fs_paths([
+    "wedding.jpg",
+    "wedding_edited.jpeg"
+])
 
 CLI_EXPORT_EDITED_SUFFIX = "_bearbeiten"
 CLI_EXPORT_EDITED_SUFFIX_TEMPLATE = "{edited?_edited,}"
@@ -149,18 +163,18 @@ CLI_EXPORT_ORIGINAL_SUFFIX = "_original"
 CLI_EXPORT_ORIGINAL_SUFFIX_TEMPLATE = "{edited?_original,}"
 CLI_EXPORT_PREVIEW_SUFFIX = "_lowres"
 
-CLI_EXPORT_FILENAMES_EDITED_SUFFIX = [
+CLI_EXPORT_FILENAMES_EDITED_SUFFIX = _normalize_fs_paths([
     "[2020-08-29] AAF035 (1).jpg",
     "[2020-08-29] AAF035 (2).jpg",
     "[2020-08-29] AAF035 (3).jpg",
     "[2020-08-29] AAF035.jpg",
     "DSC03584.dng",
-    "Frítest (1).jpg",
-    "Frítest (2).jpg",
-    "Frítest (3).jpg",
-    "Frítest_bearbeiten (1).jpeg",
-    "Frítest_bearbeiten.jpeg",
-    "Frítest.jpg",
+    "Frítest (1).jpg",
+    "Frítest (2).jpg",
+    "Frítest (3).jpg",
+    "Frítest_bearbeiten (1).jpeg",
+    "Frítest_bearbeiten.jpeg",
+    "Frítest.jpg",
     "IMG_1693.tif",
     "IMG_1994.cr2",
     "IMG_1994.JPG",
@@ -183,20 +197,20 @@ CLI_EXPORT_FILENAMES_EDITED_SUFFIX = [
     "wedding.jpg",
     "winebottle (1).jpeg",
     "winebottle.jpeg",
-]
+])
 
-CLI_EXPORT_FILENAMES_EDITED_SUFFIX_TEMPLATE = [
+CLI_EXPORT_FILENAMES_EDITED_SUFFIX_TEMPLATE = _normalize_fs_paths([
     "[2020-08-29] AAF035 (1).jpg",
     "[2020-08-29] AAF035 (2).jpg",
     "[2020-08-29] AAF035 (3).jpg",
     "[2020-08-29] AAF035.jpg",
     "DSC03584.dng",
-    "Frítest (1).jpg",
-    "Frítest (2).jpg",
-    "Frítest (3).jpg",
-    "Frítest_edited (1).jpeg",
-    "Frítest_edited.jpeg",
-    "Frítest.jpg",
+    "Frítest (1).jpg",
+    "Frítest (2).jpg",
+    "Frítest (3).jpg",
+    "Frítest_edited (1).jpeg",
+    "Frítest_edited.jpeg",
+    "Frítest.jpg",
     "IMG_1693.tif",
     "IMG_1994.cr2",
     "IMG_1994.JPG",
@@ -219,20 +233,20 @@ CLI_EXPORT_FILENAMES_EDITED_SUFFIX_TEMPLATE = [
     "wedding.jpg",
     "winebottle (1).jpeg",
     "winebottle.jpeg",
-]
+])
 
-CLI_EXPORT_FILENAMES_ORIGINAL_SUFFIX = [
+CLI_EXPORT_FILENAMES_ORIGINAL_SUFFIX = _normalize_fs_paths([
     "[2020-08-29] AAF035_original (1).jpg",
     "[2020-08-29] AAF035_original (2).jpg",
     "[2020-08-29] AAF035_original (3).jpg",
     "[2020-08-29] AAF035_original.jpg",
     "DSC03584_original.dng",
-    "Frítest_edited (1).jpeg",
-    "Frítest_edited.jpeg",
-    "Frítest_original (1).jpg",
-    "Frítest_original (2).jpg",
-    "Frítest_original (3).jpg",
-    "Frítest_original.jpg",
+    "Frítest_edited (1).jpeg",
+    "Frítest_edited.jpeg",
+    "Frítest_original (1).jpg",
+    "Frítest_original (2).jpg",
+    "Frítest_original (3).jpg",
+    "Frítest_original.jpg",
     "IMG_1693_original.tif",
     "IMG_1994_original.cr2",
     "IMG_1994_original.JPG",
@@ -255,20 +269,20 @@ CLI_EXPORT_FILENAMES_ORIGINAL_SUFFIX = [
     "wedding_original.jpg",
     "winebottle_original (1).jpeg",
     "winebottle_original.jpeg",
-]
+])
 
-CLI_EXPORT_FILENAMES_ORIGINAL_SUFFIX_TEMPLATE = [
+CLI_EXPORT_FILENAMES_ORIGINAL_SUFFIX_TEMPLATE = _normalize_fs_paths([
     "[2020-08-29] AAF035 (1).jpg",
     "[2020-08-29] AAF035 (2).jpg",
     "[2020-08-29] AAF035 (3).jpg",
     "[2020-08-29] AAF035.jpg",
     "DSC03584.dng",
-    "Frítest (1).jpg",
-    "Frítest_edited (1).jpeg",
-    "Frítest_edited.jpeg",
-    "Frítest_original (1).jpg",
-    "Frítest_original.jpg",
-    "Frítest.jpg",
+    "Frítest (1).jpg",
+    "Frítest_edited (1).jpeg",
+    "Frítest_edited.jpeg",
+    "Frítest_original (1).jpg",
+    "Frítest_original.jpg",
+    "Frítest.jpg",
     "IMG_1693.tif",
     "IMG_1994.cr2",
     "IMG_1994.JPG",
@@ -291,11 +305,11 @@ CLI_EXPORT_FILENAMES_ORIGINAL_SUFFIX_TEMPLATE = [
     "wedding_original.jpg",
     "winebottle (1).jpeg",
     "winebottle.jpeg",
-]
+])
 
 CLI_EXPORT_FILENAMES_CURRENT = [
-    "1793FAAB-DE75-4E25-886C-2BD66C780D6A_edited.jpeg",  # Frítest.jpg
-    "1793FAAB-DE75-4E25-886C-2BD66C780D6A.jpeg",  # Frítest.jpg
+    "1793FAAB-DE75-4E25-886C-2BD66C780D6A_edited.jpeg",  # Frítest.jpg
+    "1793FAAB-DE75-4E25-886C-2BD66C780D6A.jpeg",  # Frítest.jpg
     "1EB2B765-0765-43BA-A90C-0D0580E6172C.jpeg",
     "2DFD33F1-A5D8-486F-A3A9-98C07995535A.jpeg",
     "35329C57-B963-48D6-BB75-6AFF9370CBBC.mov",
@@ -311,14 +325,14 @@ CLI_EXPORT_FILENAMES_CURRENT = [
     "7F74DD34-5920-4DA3-B284-479887A34F66.jpeg",
     "7FD37B5F-6FAA-4DB1-8A29-BF9C37E38091.jpeg",
     "8846E3E6-8AC8-4857-8448-E3D025784410.tiff",
-    "A8266C97-9BAF-4AF4-99F3-0013832869B8.jpeg",  # Frítest.jpg
+    "A8266C97-9BAF-4AF4-99F3-0013832869B8.jpeg",  # Frítest.jpg
     "A92D9C26-3A50-4197-9388-CB5F7DB9FA91.cr2",
     "A92D9C26-3A50-4197-9388-CB5F7DB9FA91.jpeg",
-    "B13F4485-94E0-41CD-AF71-913095D62E31.jpeg",  # Frítest.jpg
+    "B13F4485-94E0-41CD-AF71-913095D62E31.jpeg",  # Frítest.jpg
     "D05A5FE3-15FB-49A1-A15D-AB3DA6F8B068.dng",
     "D1359D09-1373-4F3B-B0E3-1A4DE573E4A3.mp4",
-    "D1D4040D-D141-44E8-93EA-E403D9F63E07_edited.jpeg",  # Frítest.jpg
-    "D1D4040D-D141-44E8-93EA-E403D9F63E07.jpeg",  # Frítest.jpg
+    "D1D4040D-D141-44E8-93EA-E403D9F63E07_edited.jpeg",  # Frítest.jpg
+    "D1D4040D-D141-44E8-93EA-E403D9F63E07.jpeg",  # Frítest.jpg
     "D79B8D77-BFFC-460B-9312-034F2877D35B.jpeg",
     "DC99FBDD-7A52-4100-A5BB-344131646C30_edited.jpeg",
     "DC99FBDD-7A52-4100-A5BB-344131646C30.jpeg",
@@ -329,18 +343,18 @@ CLI_EXPORT_FILENAMES_CURRENT = [
     "F207D5DE-EFAD-4217-8424-0764AAC971D0.jpeg",
 ]
 
-CLI_EXPORT_FILENAMES_CONVERT_TO_JPEG = [
+CLI_EXPORT_FILENAMES_CONVERT_TO_JPEG = _normalize_fs_paths([
     "[2020-08-29] AAF035 (1).jpg",
     "[2020-08-29] AAF035 (2).jpg",
     "[2020-08-29] AAF035 (3).jpg",
     "[2020-08-29] AAF035.jpg",
     "DSC03584.jpeg",
-    "Frítest (1).jpg",
-    "Frítest (2).jpg",
-    "Frítest (3).jpg",
-    "Frítest_edited (1).jpeg",
-    "Frítest_edited.jpeg",
-    "Frítest.jpg",
+    "Frítest (1).jpg",
+    "Frítest (2).jpg",
+    "Frítest (3).jpg",
+    "Frítest_edited (1).jpeg",
+    "Frítest_edited.jpeg",
+    "Frítest.jpg",
     "IMG_1693.jpeg",
     "IMG_1994.cr2",
     "IMG_1994.JPG",
@@ -363,20 +377,20 @@ CLI_EXPORT_FILENAMES_CONVERT_TO_JPEG = [
     "wedding.jpg",
     "winebottle (1).jpeg",
     "winebottle.jpeg",
-]
+])
 
-CLI_EXPORT_FILENAMES_CONVERT_TO_JPEG_SKIP_RAW = [
+CLI_EXPORT_FILENAMES_CONVERT_TO_JPEG_SKIP_RAW = _normalize_fs_paths([
     "[2020-08-29] AAF035 (1).jpg",
     "[2020-08-29] AAF035 (2).jpg",
     "[2020-08-29] AAF035 (3).jpg",
     "[2020-08-29] AAF035.jpg",
     "DSC03584.jpeg",
-    "Frítest (1).jpg",
-    "Frítest (2).jpg",
-    "Frítest (3).jpg",
-    "Frítest_edited (1).jpeg",
-    "Frítest_edited.jpeg",
-    "Frítest.jpg",
+    "Frítest (1).jpg",
+    "Frítest (2).jpg",
+    "Frítest (3).jpg",
+    "Frítest_edited (1).jpeg",
+    "Frítest_edited.jpeg",
+    "Frítest.jpg",
     "IMG_1693.jpeg",
     "IMG_1994.JPG",
     "IMG_1997.JPG",
@@ -397,26 +411,26 @@ CLI_EXPORT_FILENAMES_CONVERT_TO_JPEG_SKIP_RAW = [
     "wedding.jpg",
     "winebottle (1).jpeg",
     "winebottle.jpeg",
-]
+])
 
 CLI_EXPORT_CONVERT_TO_JPEG_LARGE_FILE = "DSC03584.jpeg"
 
-CLI_EXPORTED_DIRECTORY_TEMPLATE_FILENAMES1 = [
+CLI_EXPORTED_DIRECTORY_TEMPLATE_FILENAMES1 = _normalize_fs_paths([
     "2019/April/wedding.jpg",
     "2019/July/Tulips.jpg",
     "2018/October/St James Park.jpg",
     "2018/September/Pumpkins3.jpg",
     "2018/September/Pumkins2.jpg",
     "2018/September/Pumkins1.jpg",
-]
+])
 
-CLI_EXPORTED_DIRECTORY_TEMPLATE_FILENAMES_LOCALE = [
+CLI_EXPORTED_DIRECTORY_TEMPLATE_FILENAMES_LOCALE = _normalize_fs_paths([
     "2019/September/IMG_9975.JPEG",
     "2020/Februar/IMG_1064.JPEG",
     "2016/März/IMG_3984.JPEG",
-]
+])
 
-CLI_EXPORTED_DIRECTORY_TEMPLATE_FILENAMES_ALBUM1 = [
+CLI_EXPORTED_DIRECTORY_TEMPLATE_FILENAMES_ALBUM1 = _normalize_fs_paths([
     "Multi Keyword/wedding.jpg",
     "_/Tulips.jpg",
     "_/St James Park.jpg",
@@ -424,9 +438,9 @@ CLI_EXPORTED_DIRECTORY_TEMPLATE_FILENAMES_ALBUM1 = [
     "Pumpkin Farm/Pumkins2.jpg",
     "Pumpkin Farm/Pumkins1.jpg",
     "Test Album/Pumkins1.jpg",
-]
+])
 
-CLI_EXPORTED_DIRECTORY_TEMPLATE_FILENAMES_ALBUM2 = [
+CLI_EXPORTED_DIRECTORY_TEMPLATE_FILENAMES_ALBUM2 = _normalize_fs_paths([
     "Multi Keyword/wedding.jpg",
     "NOALBUM/Tulips.jpg",
     "NOALBUM/St James Park.jpg",
@@ -434,28 +448,28 @@ CLI_EXPORTED_DIRECTORY_TEMPLATE_FILENAMES_ALBUM2 = [
     "Pumpkin Farm/Pumkins2.jpg",
     "Pumpkin Farm/Pumkins1.jpg",
     "Test Album/Pumkins1.jpg",
-]
+])
 
-CLI_EXPORTED_DIRECTORY_TEMPLATE_FILENAMES2 = [
+CLI_EXPORTED_DIRECTORY_TEMPLATE_FILENAMES2 = _normalize_fs_paths([
     "St James's Park, Great Britain, Westminster, England, United Kingdom/St James Park.jpg",
     "_/Pumpkins3.jpg",
     "Omaha, Nebraska, United States/Pumkins2.jpg",
     "_/Pumkins1.jpg",
     "_/Tulips.jpg",
     "_/wedding.jpg",
-]
+])
 
-CLI_EXPORTED_DIRECTORY_TEMPLATE_FILENAMES3 = [
+CLI_EXPORTED_DIRECTORY_TEMPLATE_FILENAMES3 = _normalize_fs_paths([
     "2019/{foo}/wedding.jpg",
     "2019/{foo}/Tulips.jpg",
     "2018/{foo}/St James Park.jpg",
     "2018/{foo}/Pumpkins3.jpg",
     "2018/{foo}/Pumkins2.jpg",
     "2018/{foo}/Pumkins1.jpg",
-]
+])
 
 
-CLI_EXPORTED_FILENAME_TEMPLATE_FILENAMES1 = [
+CLI_EXPORTED_FILENAME_TEMPLATE_FILENAMES1 = _normalize_fs_paths([
     "2019-wedding.jpg",
     "2019-wedding_edited.jpeg",
     "2019-Tulips.jpg",
@@ -464,9 +478,9 @@ CLI_EXPORTED_FILENAME_TEMPLATE_FILENAMES1 = [
     "2018-Pumpkins3.jpg",
     "2018-Pumkins2.jpg",
     "2018-Pumkins1.jpg",
-]
+])
 
-CLI_EXPORTED_FILENAME_TEMPLATE_FILENAMES2 = [
+CLI_EXPORTED_FILENAME_TEMPLATE_FILENAMES2 = _normalize_fs_paths([
     "Folder1_SubFolder2_AlbumInFolder-IMG_4547.jpg",
     "Folder1_SubFolder2_AlbumInFolder-wedding.jpg",
     "Folder1_SubFolder2_AlbumInFolder-wedding_edited.jpeg",
@@ -487,18 +501,18 @@ CLI_EXPORTED_FILENAME_TEMPLATE_FILENAMES2 = [
     "None-IMG_1693.tif",
     "I have a deleted twin-wedding.jpg",
     "I have a deleted twin-wedding_edited.jpeg",
-]
+])
 
-CLI_EXPORTED_FILENAME_TEMPLATE_FILENAMES_PATHSEP = [
+CLI_EXPORTED_FILENAME_TEMPLATE_FILENAMES_PATHSEP = _normalize_fs_paths([
     "2018-10 - Sponsion, Museum, Frühstück, Römermuseum/IMG_4547.jpg",
     "Folder1/SubFolder2/AlbumInFolder/IMG_4547.jpg",
     "2019-10:11 Paris Clermont/IMG_4547.jpg",
-]
+])
 
 
-CLI_EXPORTED_FILENAME_TEMPLATE_FILENAMES_KEYWORD_PATHSEP = [
+CLI_EXPORTED_FILENAME_TEMPLATE_FILENAMES_KEYWORD_PATHSEP = _normalize_fs_paths([
     "foo:bar/foo:bar_IMG_3092.heic"
-]
+])
 
 CLI_EXPORTED_FILENAME_TEMPLATE_LONG_DESCRIPTION = [
     "Lorem ipsum dolor sit amet, consectetuer adipiscing elit. Aenean commodo"
@@ -522,46 +536,59 @@ CLI_EXPORT_BY_DATE_TOUCH_UUID = [
     "F12384F6-CD17-4151-ACBA-AE0E3688539E",  # Pumkins1.jpg
 ]
 CLI_EXPORT_BY_DATE_TOUCH_TIMES = [1538165373, 1538163349]
-CLI_EXPORT_BY_DATE_NEED_TOUCH = [
+CLI_EXPORT_BY_DATE_NEED_TOUCH = _normalize_fs_paths([
     "2018/09/28/Pumkins2.jpg",
     "2018/10/13/St James Park.jpg",
-]
+])
 CLI_EXPORT_BY_DATE_NEED_TOUCH_UUID = [
     "D79B8D77-BFFC-460B-9312-034F2877D35B",
     "DC99FBDD-7A52-4100-A5BB-344131646C30",
 ]
 CLI_EXPORT_BY_DATE_NEED_TOUCH_TIMES = [1538165227, 1539436692]
-CLI_EXPORT_BY_DATE = ["2018/09/28/Pumpkins3.jpg", "2018/09/28/Pumkins1.jpg"]
+CLI_EXPORT_BY_DATE = _normalize_fs_paths([
+    "2018/09/28/Pumpkins3.jpg",
+    "2018/09/28/Pumkins1.jpg",
+])
 
-CLI_EXPORT_SIDECAR_FILENAMES = ["Pumkins2.jpg", "Pumkins2.jpg.json", "Pumkins2.jpg.xmp"]
-CLI_EXPORT_SIDECAR_DROP_EXT_FILENAMES = [
+CLI_EXPORT_SIDECAR_FILENAMES = _normalize_fs_paths([
+    "Pumkins2.jpg",
+    "Pumkins2.jpg.json",
+    "Pumkins2.jpg.xmp",
+])
+CLI_EXPORT_SIDECAR_DROP_EXT_FILENAMES = _normalize_fs_paths([
     "Pumkins2.jpg",
     "Pumkins2.json",
     "Pumkins2.xmp",
-]
+])
 
 CLI_EXPORT_LIVE = [
     "51F2BEF7-431A-4D31-8AC1-3284A57826AE.jpeg",
     "51F2BEF7-431A-4D31-8AC1-3284A57826AE.mov",
 ]
 
-CLI_EXPORT_LIVE_ORIGINAL = ["IMG_0728.JPG", "IMG_0728.mov"]
+CLI_EXPORT_LIVE_ORIGINAL = _normalize_fs_paths([
+    "IMG_0728.JPG",
+    "IMG_0728.mov",
+])
 
 CLI_EXPORT_RAW = ["441DFE2A-A69B-4C79-A69B-3F51D1B9B29C.cr2"]
-CLI_EXPORT_RAW_ORIGINAL = ["IMG_0476_2.CR2"]
+CLI_EXPORT_RAW_ORIGINAL = _normalize_fs_paths(["IMG_0476_2.CR2"])
 CLI_EXPORT_RAW_EDITED = [
     "441DFE2A-A69B-4C79-A69B-3F51D1B9B29C.cr2",
     "441DFE2A-A69B-4C79-A69B-3F51D1B9B29C_edited.jpeg",
 ]
-CLI_EXPORT_RAW_EDITED_ORIGINAL = ["IMG_0476_2.CR2", "IMG_0476_2_edited.jpeg"]
+CLI_EXPORT_RAW_EDITED_ORIGINAL = _normalize_fs_paths([
+    "IMG_0476_2.CR2",
+    "IMG_0476_2_edited.jpeg",
+])
 
 CLI_UUID_DICT_15_7 = {
     "intrash": "71E3E212-00EB-430D-8A63-5E294B268554",
     "template": "F12384F6-CD17-4151-ACBA-AE0E3688539E",
 }
 
-CLI_TEMPLATE_SIDECAR_FILENAME = "Pumkins1.jpg.json"
-CLI_TEMPLATE_FILENAME = "Pumkins1.jpg"
+CLI_TEMPLATE_SIDECAR_FILENAME = normalize_fs_path("Pumkins1.jpg.json")
+CLI_TEMPLATE_FILENAME = normalize_fs_path("Pumkins1.jpg")
 
 CLI_UUID_DICT_14_6 = {"intrash": "3tljdX43R8+k6peNHVrJNQ"}
 
@@ -899,17 +926,17 @@ UUID_IN_ALBUM = [
 ]
 
 UUID_NOT_IN_ALBUM = [
-    "1793FAAB-DE75-4E25-886C-2BD66C780D6A",  # Frítest.jpg
+    "1793FAAB-DE75-4E25-886C-2BD66C780D6A",  # Frítest.jpg
     "35329C57-B963-48D6-BB75-6AFF9370CBBC",
     "52083079-73D5-4921-AC1B-FE76F279133F",
     "6191423D-8DB8-4D4C-92BE-9BBBA308AAC4",
     "7F74DD34-5920-4DA3-B284-479887A34F66",
     "8846E3E6-8AC8-4857-8448-E3D025784410",
     "A1DD1F98-2ECD-431F-9AC9-5AFEFE2D3A5C",
-    "A8266C97-9BAF-4AF4-99F3-0013832869B8",  # Frítest.jpg
-    "B13F4485-94E0-41CD-AF71-913095D62E31",  # Frítest.jpg
+    "A8266C97-9BAF-4AF4-99F3-0013832869B8",  # Frítest.jpg
+    "B13F4485-94E0-41CD-AF71-913095D62E31",  # Frítest.jpg
     "D1359D09-1373-4F3B-B0E3-1A4DE573E4A3",
-    "D1D4040D-D141-44E8-93EA-E403D9F63E07",  # Frítest.jpg
+    "D1D4040D-D141-44E8-93EA-E403D9F63E07",  # Frítest.jpg
     "DC99FBDD-7A52-4100-A5BB-344131646C30",
     "E2078879-A29C-4D6F-BACB-E3BBE6C3EB91",
     "F207D5DE-EFAD-4217-8424-0764AAC971D0",
@@ -957,18 +984,18 @@ DESCRIPTION_VALUE_TITLE_CONDITIONAL = "false"
 
 
 UUID_UNICODE_TITLE = [
-    "B13F4485-94E0-41CD-AF71-913095D62E31",  # Frítest.jpg
-    "1793FAAB-DE75-4E25-886C-2BD66C780D6A",  # Frítest.jpg
-    "A8266C97-9BAF-4AF4-99F3-0013832869B8",  # Frítest.jpg
-    "D1D4040D-D141-44E8-93EA-E403D9F63E07",  # Frítest.jpg
+    "B13F4485-94E0-41CD-AF71-913095D62E31",  # Frítest.jpg
+    "1793FAAB-DE75-4E25-886C-2BD66C780D6A",  # Frítest.jpg
+    "A8266C97-9BAF-4AF4-99F3-0013832869B8",  # Frítest.jpg
+    "D1D4040D-D141-44E8-93EA-E403D9F63E07",  # Frítest.jpg
 ]
 
-EXPORT_UNICODE_TITLE_FILENAMES = [
-    "Frítest.jpg",
-    "Frítest (1).jpg",
-    "Frítest (2).jpg",
-    "Frítest (3).jpg",
-]
+EXPORT_UNICODE_TITLE_FILENAMES = _normalize_fs_paths([
+    "Frítest.jpg",
+    "Frítest (1).jpg",
+    "Frítest (2).jpg",
+    "Frítest (3).jpg",
+])
 
 # data for --report
 UUID_REPORT = [
@@ -990,12 +1017,12 @@ QUERY_EXIF_DATA_CASE_INSENSITIVE = [
 EXPORT_EXIF_DATA = [("EXIF:Make", "FUJIFILM", ["Tulips.jpg", "Tulips_edited.jpeg"])]
 
 UUID_LIVE_EDITED = "136A78FA-1B90-46CC-88A7-CCA3331F0353"  # IMG_4813.HEIC
-CLI_EXPORT_LIVE_EDITED = [
+CLI_EXPORT_LIVE_EDITED = _normalize_fs_paths([
     "IMG_4813.HEIC",
     "IMG_4813.mov",
     "IMG_4813_edited.jpeg",
     "IMG_4813_edited.mov",
-]
+])
 
 UUID_FAVORITE = "E9BC5C36-7CD1-40A1-A72B-8B8FAC227D51"
 FILE_FAVORITE = "wedding.jpg"

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,13 +32,13 @@ from osxphotos.cli import (
     labels,
     persons,
     places,
+    query,
 )
 from osxphotos.exiftool import ExifTool, get_exiftool_path
 from osxphotos.fileutil import FileUtil
 from osxphotos.utils import is_macos, noop, normalize_fs_path, normalize_unicode
 if is_macos:
     from osxmetadata import OSXMetaData, Tag
-    from osxphotos.cli import query
 
 from .conftest import copy_photos_library_to_path
 from .locale_util import setlocale
@@ -1121,7 +1121,6 @@ def test_about():
     assert "MIT License" in result.output
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_uuid():
 
     runner = CliRunner()
@@ -1156,7 +1155,6 @@ def test_query_uuid():
             assert json_expected[key_] in json_got[key_]
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_uuid_from_file_1():
     """Test query with --uuid-from-file"""
 
@@ -1180,7 +1178,6 @@ def test_query_uuid_from_file_1():
     assert sorted(UUID_EXPECTED_FROM_FILE) == sorted(uuid_got)
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_uuid_from_file_stdin():
     """Test query with --uuid-from-file reading from stdin"""
 
@@ -1200,7 +1197,6 @@ def test_query_uuid_from_file_stdin():
     assert sorted(UUID_EXPECTED_FROM_FILE) == sorted(uuid_got)
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_has_comment():
     """Test query with --has-comment"""
 
@@ -1218,7 +1214,6 @@ def test_query_has_comment():
     assert sorted(uuid_got) == sorted(UUID_HAS_COMMENTS)
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_no_comment():
     """Test query with --no-comment"""
 
@@ -1238,7 +1233,6 @@ def test_query_no_comment():
         assert uuid not in UUID_HAS_COMMENTS
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_has_likes():
     """Test query with --has-likes"""
 
@@ -1255,7 +1249,6 @@ def test_query_has_likes():
     assert sorted(uuid_got) == sorted(UUID_HAS_LIKES)
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_no_likes():
     """Test query with --no-likes"""
 
@@ -1275,7 +1268,6 @@ def test_query_no_likes():
         assert uuid not in UUID_HAS_LIKES
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_is_reference():
     """Test query with --is-reference"""
 
@@ -1292,7 +1284,6 @@ def test_query_is_reference():
     assert sorted(uuid_got) == sorted(UUID_IS_REFERENCE)
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_edited():
     """Test query with --edited"""
 
@@ -1309,7 +1300,6 @@ def test_query_edited():
     assert sorted(uuid_got) == sorted(UUID_EDITED)
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_not_edited():
     """Test query with --not-edited"""
 
@@ -1326,7 +1316,6 @@ def test_query_not_edited():
     assert sorted(uuid_got) == sorted(UUID_NOT_EDITED)
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_in_album():
     """Test query with --in-album"""
 
@@ -1343,7 +1332,6 @@ def test_query_in_album():
     assert sorted(uuid_got) == sorted(UUID_IN_ALBUM)
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_not_in_album():
     """Test query with --not-in-album"""
 
@@ -1360,7 +1348,6 @@ def test_query_not_in_album():
     assert sorted(uuid_got) == sorted(UUID_NOT_IN_ALBUM)
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_duplicate():
     """Test query with --duplicate"""
 
@@ -1378,7 +1365,6 @@ def test_query_duplicate():
     assert sorted(uuid_got) == sorted(UUID_DUPLICATES)
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_location():
     """Test query with --location"""
 
@@ -1397,7 +1383,6 @@ def test_query_location():
     assert UUID_NO_LOCATION not in uuid_got
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_no_location():
     """Test query with --no-location"""
 
@@ -1416,7 +1401,6 @@ def test_query_no_location():
     assert UUID_LOCATION not in uuid_got
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 @pytest.mark.skipif(exiftool is None, reason="exiftool not installed")
 @pytest.mark.parametrize("exiftag,exifvalue,uuid_expected", QUERY_EXIF_DATA)
 def test_query_exif(exiftag, exifvalue, uuid_expected):
@@ -1443,7 +1427,6 @@ def test_query_exif(exiftag, exifvalue, uuid_expected):
     assert sorted(uuid_got) == sorted(uuid_expected)
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 @pytest.mark.skipif(exiftool is None, reason="exiftool not installed")
 @pytest.mark.parametrize(
     "exiftag,exifvalue,uuid_expected", QUERY_EXIF_DATA_CASE_INSENSITIVE
@@ -1473,7 +1456,6 @@ def test_query_exif_case_insensitive(exiftag, exifvalue, uuid_expected):
     assert sorted(uuid_got) == sorted(uuid_expected)
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 @pytest.mark.skipif(exiftool is None, reason="exiftool not installed")
 def test_query_exif_multiple():
     """Test query with multiple --exif options, #873"""
@@ -2747,7 +2729,6 @@ def test_export_duplicate_unicode_filenames():
         assert sorted(files) == sorted(EXPORT_UNICODE_TITLE_FILENAMES)
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_date_1():
     """Test --from-date and --to-date"""
 
@@ -2772,7 +2753,6 @@ def test_query_date_1():
     assert len(json_got) == 4
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_date_2():
     """Test --from-date and --to-date"""
 
@@ -2797,7 +2777,6 @@ def test_query_date_2():
     assert len(json_got) == 2
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_date_timezone():
     """Test --from-date, --to-date with ISO 8601 timezone"""
 
@@ -2822,7 +2801,6 @@ def test_query_date_timezone():
     assert len(json_got) == 4
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_time():
     """Test --from-time, --to-time"""
 
@@ -2847,7 +2825,6 @@ def test_query_time():
     assert len(json_got) == 3
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_year_1():
     """Test --year"""
 
@@ -2872,7 +2849,6 @@ def test_query_year_1():
     assert len(json_got) == 1
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_year_2():
     """Test --year with multiple years"""
 
@@ -2899,7 +2875,6 @@ def test_query_year_2():
     assert len(json_got) == 6
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_year_3():
     """Test --year with invalid year"""
 
@@ -2924,7 +2899,6 @@ def test_query_year_3():
     assert len(json_got) == 0
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_keyword_1():
     """Test query --keyword"""
 
@@ -2939,7 +2913,6 @@ def test_query_keyword_1():
     assert len(json_got) == 4
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_keyword_2():
     """Test query --keyword with lower case keyword"""
 
@@ -2954,7 +2927,6 @@ def test_query_keyword_2():
     assert len(json_got) == 0
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_keyword_3():
     """Test query --keyword with lower case keyword and --ignore-case"""
 
@@ -2976,7 +2948,6 @@ def test_query_keyword_3():
     assert len(json_got) == 4
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_keyword_4():
     """Test query with more than one --keyword"""
 
@@ -2999,7 +2970,6 @@ def test_query_keyword_4():
     assert len(json_got) == 6
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_no_keyword():
     """Test query --no-keyword"""
 
@@ -3021,7 +2991,6 @@ def test_query_no_keyword():
     assert len(json_got) == 11
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_person_1():
     """Test query --person"""
 
@@ -3036,7 +3005,6 @@ def test_query_person_1():
     assert len(json_got) == 3
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_person_2():
     """Test query --person with lower case person"""
 
@@ -3051,7 +3019,6 @@ def test_query_person_2():
     assert len(json_got) == 0
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_person_3():
     """Test query --person with lower case person and --ignore-case"""
 
@@ -3073,7 +3040,6 @@ def test_query_person_3():
     assert len(json_got) == 3
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_person_4():
     """Test query with multiple --person"""
 
@@ -3096,7 +3062,6 @@ def test_query_person_4():
     assert len(json_got) == 4
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_album_1():
     """Test query --album"""
 
@@ -3117,7 +3082,6 @@ def test_query_album_1():
     assert len(json_got) == 3
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_album_2():
     """Test query --album with lower case album"""
 
@@ -3138,7 +3102,6 @@ def test_query_album_2():
     assert len(json_got) == 0
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_album_3():
     """Test query --album with lower case album and --ignore-case"""
 
@@ -3160,7 +3123,6 @@ def test_query_album_3():
     assert len(json_got) == 3
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_album_4():
     """Test query with multipl --album"""
 
@@ -3183,7 +3145,6 @@ def test_query_album_4():
     assert len(json_got) == 7
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_label_1():
     """Test query --label"""
 
@@ -3198,7 +3159,6 @@ def test_query_label_1():
     assert len(json_got) == 1
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_label_2():
     """Test query --label with lower case label"""
 
@@ -3213,7 +3173,6 @@ def test_query_label_2():
     assert len(json_got) == 0
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_label_3():
     """Test query --label with lower case label and --ignore-case"""
 
@@ -3235,7 +3194,6 @@ def test_query_label_3():
     assert len(json_got) == 1
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_label_4():
     """Test query with more than one --label"""
 
@@ -3258,7 +3216,6 @@ def test_query_label_4():
     assert len(json_got) == 1
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_deleted_deleted_only():
     """Test query with --deleted and --deleted-only"""
 
@@ -3277,7 +3234,6 @@ def test_query_deleted_deleted_only():
     assert "Incompatible query options" in result.output
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_deleted_1():
     """Test query with --deleted"""
 
@@ -3291,7 +3247,6 @@ def test_query_deleted_1():
     assert len(json_got) == PHOTOS_NOT_IN_TRASH_LEN_15_7 + PHOTOS_IN_TRASH_LEN_15_7
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_deleted_2():
     """Test query with --deleted"""
 
@@ -3305,7 +3260,6 @@ def test_query_deleted_2():
     assert len(json_got) == PHOTOS_NOT_IN_TRASH_LEN_15_7 + PHOTOS_IN_TRASH_LEN_15_7
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_deleted_3():
     """Test query with --deleted-only"""
 
@@ -3320,7 +3274,6 @@ def test_query_deleted_3():
     assert json_got[0]["intrash"]
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_deleted_4():
     """Test query with --deleted-only"""
 
@@ -4312,7 +4265,6 @@ def test_places():
         assert json_got == json.loads(CLI_PLACES_JSON)
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_place_13():
     # test --place on 10.13
 
@@ -4337,7 +4289,6 @@ def test_place_13():
         assert json_got[0]["uuid"] == "2L6X2hv3ROWRSCU3WRRAGQ"
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_no_place_13():
     # test --no-place on 10.13
 
@@ -4356,7 +4307,6 @@ def test_no_place_13():
         assert json_got[0]["uuid"] == "pERZk5T1Sb+XcKDFRCsGpA"
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_place_15_1():
     # test --place on 10.15
 
@@ -4381,7 +4331,6 @@ def test_place_15_1():
         assert json_got[0]["uuid"] == "128FB4C6-0B16-4E7D-9108-FB2E90DA1546"
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_place_15_2():
     # test --place on 10.15
 
@@ -4408,7 +4357,6 @@ def test_place_15_2():
         assert "FF7AFE2C-49B0-4C9B-B0D7-7E1F8B8F2F0C" in uuid
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_no_place_15():
     # test --no-place on 10.15
 
@@ -4426,7 +4374,6 @@ def test_no_place_15():
         assert json_got[0]["uuid"] == "A9B73E13-A6F2-4915-8D67-7213B39BAE9F"
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_no_folder_1_15():
     # test --folder on 10.15
 
@@ -4467,7 +4414,6 @@ def test_no_folder_1_15():
                 ]
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_no_folder_2_15():
     # test --folder with --uuid on 10.15
 
@@ -4498,7 +4444,6 @@ def test_no_folder_2_15():
             )
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_no_folder_1_14():
     # test --folder on 10.14
 
@@ -4735,7 +4680,6 @@ def test_export_force_update():
             export, [os.path.join(cwd, photos_db_path), ".", "--force-update"]
         )
         assert result.exit_code == 0
-        print(result.output)
         assert (
             f"Processed: {PHOTOS_NOT_IN_TRASH_LEN_15_7} photos, exported: 0, updated: 0, skipped: {PHOTOS_NOT_IN_TRASH_LEN_15_7+PHOTOS_EDITED_15_7}, updated EXIF data: 0, missing: 3, error: 0"
             in result.output
@@ -7709,7 +7653,6 @@ def test_export_skip_live_photokit():
             assert sorted(files) == sorted(UUID_SKIP_LIVE_PHOTOKIT[uuid])
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_name():
     """test query --name"""
 
@@ -7726,7 +7669,6 @@ def test_query_name():
     assert json_got[0]["original_filename"] == "DSC03584.dng"
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_name_unicode():
     """test query --name with a unicode name"""
 
@@ -7745,7 +7687,6 @@ def test_query_name_unicode():
     )
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_name_i():
     """test query --name -i"""
 
@@ -7769,7 +7710,6 @@ def test_query_name_i():
     assert json_got[0]["original_filename"] == "DSC03584.dng"
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_name_original_filename():
     """test query --name only searches original filename on Photos 5+"""
 
@@ -7785,7 +7725,6 @@ def test_query_name_original_filename():
     assert len(json_got) == 4
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_name_original_filename_i():
     """test query --name only searches original filename on Photos 5+ with -i"""
 
@@ -7859,7 +7798,6 @@ def test_bad_query_eval():
         assert "Invalid query-eval CRITERIA" in result.output
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_min_size_1():
     """test query --min-size"""
 
@@ -7875,7 +7813,6 @@ def test_query_min_size_1():
     assert len(json_got) == 4
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_min_size_2():
     """test query --min-size"""
 
@@ -7897,7 +7834,6 @@ def test_query_min_size_2():
     assert len(json_got) == 4
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_max_size_1():
     """test query --max-size"""
 
@@ -7913,7 +7849,6 @@ def test_query_max_size_1():
     assert len(json_got) == 3
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_max_size_2():
     """test query --max-size"""
 
@@ -7929,7 +7864,6 @@ def test_query_max_size_2():
     assert len(json_got) == 3
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_min_max_size():
     """test query --max-size with --min-size"""
 
@@ -7953,7 +7887,6 @@ def test_query_min_max_size():
     assert len(json_got) == 1
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_min_size_error():
     """test query --max-size with invalid size"""
 
@@ -7966,7 +7899,6 @@ def test_query_min_size_error():
     assert result.exit_code != 0
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_regex_1():
     """test query --regex against title"""
 
@@ -7989,7 +7921,6 @@ def test_query_regex_1():
     assert len(json_got) == 1
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_regex_2():
     """test query --regex with no match"""
 
@@ -8012,7 +7943,6 @@ def test_query_regex_2():
     assert len(json_got) == 0
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_regex_3():
     """test query --regex with --ignore-case"""
 
@@ -8036,7 +7966,6 @@ def test_query_regex_3():
     assert len(json_got) == 1
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_regex_4():
     """test query --regex against album"""
 
@@ -8059,7 +7988,6 @@ def test_query_regex_4():
     assert len(json_got) == 2
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_regex_multiple():
     """test query multiple --regex values (#525)"""
 
@@ -8085,7 +8013,6 @@ def test_query_regex_multiple():
     assert len(json_got) == 2
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_function():
     """test query --query-function"""
 
@@ -8117,7 +8044,6 @@ def test_query_function():
         assert json_got[0]["original_filename"] == "DSC03584.dng"
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_added_after():
     """test query --added-after"""
 
@@ -8139,7 +8065,6 @@ def test_query_added_after():
     assert len(json_got) == 4
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_added_before():
     """test query --added-before"""
 
@@ -8161,7 +8086,6 @@ def test_query_added_before():
     assert len(json_got) == 7
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_added_in_last():
     """test query --added-in-last"""
 
@@ -8507,7 +8431,6 @@ def test_export_directory_template_function():
         assert pathlib.Path(f"foo/bar/{CLI_EXPORT_UUID_FILENAME}").is_file()
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_export_query_function():
     """Test --query-function"""
 
@@ -8862,7 +8785,6 @@ def test_export_print():
         assert f"uuid: {UUID_FAVORITE}" in result.output
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_print_quiet():
     """test query --print"""
 
@@ -8885,7 +8807,6 @@ def test_query_print_quiet():
         assert result.output.strip() == f"uuid: {UUID_FAVORITE}"
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_field():
     """test query --field"""
 
@@ -8911,7 +8832,6 @@ def test_query_field():
         assert result.output.strip() == f"uuid,name\n{UUID_FAVORITE},{FILE_FAVORITE}"
 
 
-@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_query_field_json():
     """test query --field --json"""
 

--- a/tests/test_cli_add_locations.py
+++ b/tests/test_cli_add_locations.py
@@ -1,10 +1,14 @@
 """Test osxphotos add-locations command"""
 
-import photoscript
 import pytest
 from click.testing import CliRunner
 
-from osxphotos.cli.add_locations import add_locations
+from osxphotos.utils import is_macos
+if is_macos:
+    import photoscript
+    from osxphotos.cli.add_locations import add_locations
+else:
+    pytest.skip(allow_module_level=True)
 
 UUID_TEST_PHOTO_1 = "F12384F6-CD17-4151-ACBA-AE0E3688539E"  # Pumkins1.jpg
 UUID_TEST_PHOTO_LOCATION = "D79B8D77-BFFC-460B-9312-034F2877D35B"  # Pumkins2.jpg

--- a/tests/test_cli_add_to_album.py
+++ b/tests/test_cli_add_to_album.py
@@ -2,9 +2,14 @@
 
 import os
 
-import photoscript
 import pytest
 from click.testing import CliRunner
+
+from osxphotos.utils import is_macos
+if is_macos:
+    import photoscript
+else:
+    pytest.skip(allow_module_level=True)
 
 UUID_EXPORT = {"3DD2C897-F19E-4CA6-8C22-B027D5A71907": {"filename": "IMG_4547.jpg"}}
 UUID_MISSING = {

--- a/tests/test_cli_all_commands.py
+++ b/tests/test_cli_all_commands.py
@@ -24,7 +24,6 @@ TEST_RUN_SCRIPT = "examples/cli_example_1.py"
 def runner() -> CliRunner:
     return CliRunner()
 
-
 from osxphotos.cli import (
     about,
     albums,
@@ -42,9 +41,13 @@ from osxphotos.cli import (
     places,
     theme,
     tutorial,
-    uuid,
     version,
 )
+
+from osxphotos.utils import is_macos
+
+if is_macos:
+    from osxphotos.cli import uuid
 
 
 def test_about(runner: CliRunner):
@@ -68,9 +71,8 @@ def test_about(runner: CliRunner):
         persons,
         places,
         tutorial,
-        uuid,
         version,
-    ],
+    ] + ([uuid] if is_macos else []),
 )
 def test_cli_comands(runner: CliRunner, command: Callable[..., Any]):
     with runner.isolated_filesystem():

--- a/tests/test_cli_batch_edit.py
+++ b/tests/test_cli_batch_edit.py
@@ -5,12 +5,17 @@ from __future__ import annotations
 import os
 import time
 
-import photoscript
 import pytest
 from click.testing import CliRunner
 
 import osxphotos
-from osxphotos.cli.batch_edit import batch_edit
+from osxphotos.utils import is_macos
+
+if is_macos:
+    import photoscript
+    from osxphotos.cli.batch_edit import batch_edit
+else:
+    pytest.skip(allow_module_level=True)
 
 # set timezone to avoid issues with comparing dates
 os.environ["TZ"] = "US/Pacific"

--- a/tests/test_cli_import.py
+++ b/tests/test_cli_import.py
@@ -14,16 +14,22 @@ from tempfile import TemporaryDirectory
 from typing import Dict
 
 import pytest
+
 from click.testing import CliRunner
-from photoscript import Photo
 from pytest import MonkeyPatch, approx
 
 from osxphotos import PhotosDB, QueryOptions
 from osxphotos._constants import UUID_PATTERN
-from osxphotos.cli.import_cli import import_cli
 from osxphotos.datetime_utils import datetime_remove_tz
 from osxphotos.exiftool import get_exiftool_path
+from osxphotos.utils import is_macos
 from tests.conftest import get_os_version
+
+if is_macos:
+    from photoscript import Photo
+    from osxphotos.cli.import_cli import import_cli
+else:
+    pytest.skip(allow_module_level=True)
 
 TERMINAL_WIDTH = 250
 

--- a/tests/test_cli_sync.py
+++ b/tests/test_cli_sync.py
@@ -2,11 +2,15 @@
 
 import os
 import json
-import photoscript
 import pytest
 from click.testing import CliRunner
 
-from osxphotos.cli.sync import sync
+from osxphotos.utils import is_macos
+if is_macos:
+    import photoscript
+    from osxphotos.cli.sync import sync
+else:
+    pytest.skip(allow_module_level=True)
 
 UUID_TEST_PHOTO_1 = "D79B8D77-BFFC-460B-9312-034F2877D35B"  # Pumkins2.jpg
 UUID_TEST_PHOTO_2 = "E9BC5C36-7CD1-40A1-A72B-8B8FAC227D51"  # wedding.jpg

--- a/tests/test_datetime_formatter.py
+++ b/tests/test_datetime_formatter.py
@@ -1,6 +1,8 @@
 """ test datetime_formatter.DateTimeFormatter """
 import pytest
 
+from .locale_util import setlocale
+
 
 def test_datetime_formatter_1():
     """Test DateTimeFormatter """
@@ -8,7 +10,7 @@ def test_datetime_formatter_1():
     import locale
     from osxphotos.datetime_formatter import DateTimeFormatter
 
-    locale.setlocale(locale.LC_ALL, "en_US")
+    setlocale(locale.LC_ALL, "en_US")
 
     dt = datetime.datetime(2020, 5, 23, 12, 42, 33)
     dtf = DateTimeFormatter(dt)
@@ -32,7 +34,7 @@ def test_datetime_formatter_2():
     import locale
     from osxphotos.datetime_formatter import DateTimeFormatter
 
-    locale.setlocale(locale.LC_ALL, "en_US")
+    setlocale(locale.LC_ALL, "en_US")
 
     dt = datetime.datetime(2020, 5, 23, 14, 42, 33)
     dtf = DateTimeFormatter(dt)
@@ -56,7 +58,7 @@ def test_datetime_formatter_3():
     import locale
     from osxphotos.datetime_formatter import DateTimeFormatter
 
-    locale.setlocale(locale.LC_ALL, "en_US")
+    setlocale(locale.LC_ALL, "en_US")
 
     dt = datetime.datetime(2020, 5, 2, 9, 3, 6)
     dtf = DateTimeFormatter(dt)

--- a/tests/test_exiftool.py
+++ b/tests/test_exiftool.py
@@ -538,13 +538,13 @@ def test_exiftool_terminate():
 
     ps = subprocess.run(["ps"], capture_output=True)
     stdout = ps.stdout.decode("utf-8")
-    assert "exiftool -stay_open" in stdout
+    assert "exiftool" in stdout
 
     osxphotos.exiftool.terminate_exiftool()
 
     ps = subprocess.run(["ps"], capture_output=True)
     stdout = ps.stdout.decode("utf-8")
-    assert "exiftool -stay_open" not in stdout
+    assert "exiftool" not in stdout
 
     # verify we can create a new instance after termination
     exif2 = osxphotos.exiftool.ExifTool(TEST_FILE_ONE_KEYWORD)

--- a/tests/test_export_catalina_10_15_7_use_photos_export.py
+++ b/tests/test_export_catalina_10_15_7_use_photos_export.py
@@ -2,9 +2,9 @@ import os
 import pytest
 
 from osxphotos._constants import _UNKNOWN_PERSON
-from osxphotos.utils import get_macos_version
+from osxphotos.utils import is_macos, get_macos_version
 
-OS_VERSION = get_macos_version()
+OS_VERSION = get_macos_version() if is_macos else (None, None, None)
 SKIP_TEST = "OSXPHOTOS_TEST_EXPORT" not in os.environ or OS_VERSION[1] != "15"
 PHOTOS_DB = os.path.expanduser("~/Pictures/Photos Library.photoslibrary")
 pytestmark = pytest.mark.skipif(

--- a/tests/test_fileutil.py
+++ b/tests/test_fileutil.py
@@ -74,10 +74,12 @@ def test_hardlink_file_valid():
 
     temp_dir = tempfile.TemporaryDirectory(prefix="osxphotos_")
     src = "tests/test-images/wedding.jpg"
+    src2 = os.path.join(temp_dir.name, "wedding_src.jpg")
     dest = os.path.join(temp_dir.name, "wedding.jpg")
-    FileUtil.hardlink(src, dest)
+    FileUtil.copy(src, src2)
+    FileUtil.hardlink(src2, dest)
     assert os.path.isfile(dest)
-    assert os.path.samefile(src, dest)
+    assert os.path.samefile(src2, dest)
 
 
 def test_unlink_file():

--- a/tests/test_monterey_dev_beta_12_0_0.py
+++ b/tests/test_monterey_dev_beta_12_0_0.py
@@ -14,9 +14,9 @@ import pytest
 import osxphotos
 from osxphotos._constants import _UNKNOWN_PERSON
 from osxphotos.photoexporter import PhotoExporter
-from osxphotos.utils import get_macos_version
+from osxphotos.utils import is_macos, get_macos_version
 
-OS_VERSION = get_macos_version()
+OS_VERSION = get_macos_version() if is_macos else (None, None, None)
 # SKIP_TEST = "OSXPHOTOS_TEST_EXPORT" not in os.environ or OS_VERSION[1] != "17"
 SKIP_TEST = True  # don't run any of the local library tests
 PHOTOS_DB_LOCAL = os.path.expanduser("~/Pictures/Photos Library.photoslibrary")

--- a/tests/test_photokit.py
+++ b/tests/test_photokit.py
@@ -6,15 +6,19 @@ import tempfile
 
 import pytest
 
-from osxphotos.photokit import (
-    LivePhotoAsset,
-    PhotoAsset,
-    PhotoLibrary,
-    VideoAsset,
-    PHOTOS_VERSION_CURRENT,
-    PHOTOS_VERSION_ORIGINAL,
-    PHOTOS_VERSION_UNADJUSTED,
-)
+from osxphotos.utils import is_macos
+if is_macos:
+    from osxphotos.photokit import (
+        LivePhotoAsset,
+        PhotoAsset,
+        PhotoLibrary,
+        VideoAsset,
+        PHOTOS_VERSION_CURRENT,
+        PHOTOS_VERSION_ORIGINAL,
+        PHOTOS_VERSION_UNADJUSTED,
+    )
+else:
+    pytest.skip(allow_module_level=True)
 
 skip_test = "OSXPHOTOS_TEST_EXPORT" not in os.environ
 pytestmark = pytest.mark.skipif(

--- a/tests/test_template_today.py
+++ b/tests/test_template_today.py
@@ -5,6 +5,8 @@ import pytest
 import osxphotos
 from osxphotos.phototemplate import RenderOptions
 
+from .locale_util import setlocale
+
 PHOTOS_DB_PLACES = (
     "./tests/Test-Places-Catalina-10_15_1.photoslibrary/database/photos.db"
 )
@@ -48,7 +50,7 @@ def test_subst_today(photosdb):
     """Test that substitutions are correct for {today.x}"""
     import locale
 
-    locale.setlocale(locale.LC_ALL, "en_US")
+    setlocale(locale.LC_ALL, "en_US")
     photo = photosdb.photos(uuid=[UUID_DICT["place_dc"]])[0]
 
     photo_template = osxphotos.PhotoTemplate(photo)
@@ -64,7 +66,7 @@ def test_subst_strftime_today(photosdb):
     """Test that strftime substitutions are correct for {today.strftime}"""
     import locale
 
-    locale.setlocale(locale.LC_ALL, "en_US")
+    setlocale(locale.LC_ALL, "en_US")
     photo = photosdb.photos(uuid=[UUID_DICT["place_dc"]])[0]
 
     photo_template = osxphotos.PhotoTemplate(photo)

--- a/tests/test_uti.py
+++ b/tests/test_uti.py
@@ -8,6 +8,7 @@ from osxphotos.uti import (
     get_preferred_uti_extension,
     get_uti_for_extension,
 )
+from osxphotos.utils import is_macos
 
 EXT_DICT = {"heic": "public.heic", "jpg": "public.jpeg", ".jpg": "public.jpeg"}
 UTI_DICT = {"public.heic": "heic", "public.jpeg": "jpeg"}
@@ -43,12 +44,14 @@ def test_get_uti_for_extension_no_objc():
     osxphotos.uti.OS_VER = OLD_VER
 
 
+@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_get_uti_from_mdls():
     """get _get_uti_from_mdls"""
     for ext in EXT_DICT:
         assert _get_uti_from_mdls(ext) == EXT_DICT[ext]
 
 
+@pytest.mark.skipif(not is_macos, reason="Only works on macOS")
 def test_get_uti_not_in_dict():
     """get UTI when objc is not available and it's not in the EXT_UTI_DICT"""
     # monkey patch the EXT_UTI_DICT


### PR DESCRIPTION
This PR allows osxphotos to run on non-MacOS platforms (tested on NixOS Linux), both as a library and a CLI tool. This is accomplished mainly by gating specific functionality behind OS checks and providing alternative codepaths where necessary.

This mostly doesn't bring any complexity to the codebase, except for the need to gate new MacOS specific code and the need to deal with Unicode normalisation. MacOS does it in the background, other OSs can theoretically deal with any form of Unicode, but it seems Photos databases aren't internally consistent, so the best solution is to normalise on output.

Two tests are failing, `tests/test_cli.py::test_export_touch_files` and `test_export_touch_files_update`. I don't understand why only 31 files should be touched, so I can't fix the test. Other tests are either skipped or run fine.

A port to Linux will allow running tests on GitHub's CI platform, but that's not part of this PR.