### PR TITLE
Fix two undefined names in phototemplate.py

### DIFF
--- a/osxphotos/phototemplate.py
+++ b/osxphotos/phototemplate.py
@@ -21,6 +21,7 @@ from ._version import __version__
 from .datetime_formatter import DateTimeFormatter
 from .exiftool import ExifToolCaching
 from .path_utils import sanitize_dirname, sanitize_filename, sanitize_pathpart
+from .photoinfo import PhotoInfo
 from .text_detection import detect_text
 from .utils import expand_and_validate_filepath, load_function, uuid_to_shortuuid
 
@@ -1153,7 +1154,7 @@ class PhotoTemplate:
                 )
             except ValueError as e:
                 raise SyntaxError(
-                    f"comparison operators may only be used with values that can be converted to numbers: {vals} {conditional_value}"
+                    f"comparison operators may only be used with values that can be converted to numbers: {value} {conditional_value}"
                 ) from e
 
         predicate_is_true = False

--- a/osxphotos/phototemplate.py
+++ b/osxphotos/phototemplate.py
@@ -21,7 +21,6 @@ from ._version import __version__
 from .datetime_formatter import DateTimeFormatter
 from .exiftool import ExifToolCaching
 from .path_utils import sanitize_dirname, sanitize_filename, sanitize_pathpart
-from .photoinfo import PhotoInfo
 from .text_detection import detect_text
 from .utils import expand_and_validate_filepath, load_function, uuid_to_shortuuid
 
@@ -1683,7 +1682,7 @@ def format_date_field(dt: datetime.datetime, field: str, args: List[str]) -> str
             raise ValueError(f"Unhandled template value: {field}") from e
 
 
-def get_place_value(photo: "PhotoInfo", field: str):
+def get_place_value(photo: "PhotoInfo", field: str):  # noqa: F821
     """Get the value of a 'place' field by attribute
 
     Args:


### PR DESCRIPTION
% `ruff --exit-zero --select=E9,F63,F7,F82,YTT .`
```
osxphotos/cli/report_writer.py:22:1: F822 Undefined name `ExportReportWriterSqlite` in `__all__`
osxphotos/cli/report_writer.py:22:1: F822 Undefined name `SyncReportWriterSqlite` in `__all__`
osxphotos/phototemplate.py:1156:108: F821 Undefined name `vals`
osxphotos/phototemplate.py:1685:29: F821 Undefined name `PhotoInfo`
Found 4 errors.
```