### PR TITLE
Lint Python twice: 1. Whole repo, 2. Exclude tests/

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -7,9 +7,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v3
-    - run: pip install --user ruff
+    - run: pip install --user ruff  # Lint Python twice: 1. Whole repo, 2. Exclude tests/
     - run: ruff --format=github --line-length=7228 --target-version=py39
-                --ignore=E402,E712,E721,E722,E741,F401,F403,F405,F541,F601,F811,F821,F822,F841 .
+                --ignore=E402,E712,E721,E722,E741,F401,F403,F405,F541,F601,F811,F822,F841 .
+    - run: ruff --format=github --line-length=366 --target-version=py39
+                --exclude=tests/ --ignore=E402,E722,E741,F401,F403,F405,F541,F822,F841 .
   build:
     runs-on: ${{ matrix.os }}
     if: "!contains(github.event.head_commit.message, '[skip ci]')"

--- a/osxphotos/cli/timewarp.py
+++ b/osxphotos/cli/timewarp.py
@@ -164,7 +164,7 @@ See also `osxphotos help timewarp` for more information on the timewarp
 command which can be used to change the time zone of photos after import.
 
 
-"""
+"""  # noqa: E501
                 ),
                 width=formatter.width,
                 markdown=True,

--- a/osxphotos/configoptions.py
+++ b/osxphotos/configoptions.py
@@ -50,7 +50,7 @@ class ConfigOptions:
             try:
                 arg = args[attr]
                 # don't test 'not arg'; need to handle empty strings as valid values
-                if arg in (False, None):
+                if arg is None or arg is False:
                     if type(self._attrs[attr]) == tuple:
                         setattr(self, attr, ())
                     else:

--- a/osxphotos/configoptions.py
+++ b/osxphotos/configoptions.py
@@ -50,7 +50,7 @@ class ConfigOptions:
             try:
                 arg = args[attr]
                 # don't test 'not arg'; need to handle empty strings as valid values
-                if arg is None or arg == False:
+                if arg in (False, None):
                     if type(self._attrs[attr]) == tuple:
                         setattr(self, attr, ())
                     else:


### PR DESCRIPTION
Both runs take less than a second so...
`line-length=366` is more reasonable.
```
    - run: ruff --format=github --line-length=7228 --target-version=py39
                --ignore=E402,E712,E721,E722,E741,F401,F403,F405,F541,F601,F811,F822,F841 .
    - run: ruff --format=github --line-length=366 --target-version=py39
                --exclude=tests/ --ignore=E402,E722,E741,F401,F403,F405,F541,F822,F841 .
```