### PR TITLE
Added beta macos runners

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -18,7 +18,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        os: [macos-latest]
+        os: [macos-latest-xl]
         python-version: ['3.9', '3.10', '3.11']
 
     steps:


### PR DESCRIPTION
https://github.blog/changelog/2023-04-24-github-actions-faster-macos-runners-are-now-available-in-open-public-beta/