### PR TITLE
Add .AAE adjustment export (fix #97)

### DIFF
--- a/osxphotos/cli/export.py
+++ b/osxphotos/cli/export.py
@@ -298,6 +298,14 @@ from .verbose import get_verbose_console, verbose_print
     "only the primary photo will be exported--associated burst images will be skipped.",
 )
 @click.option(
+    "--export-aae",
+    is_flag=True,
+    help="Also export an adjustments file detailing edits made to the original. "
+    "The resulting file is named photoname.AAE. "
+    "Note that to import these files back to Photos succesfully, you also need to "
+    "export the edited photo and match the filename format Photos.app expects: "
+    "--filename 'IMG_{edited_version?E,}{id:04d}' --edited-suffix ''")
+@click.option(
     "--sidecar",
     default=None,
     multiple=True,
@@ -852,6 +860,7 @@ def export(
     screenshot,
     selfie,
     shared,
+    export_aae,
     sidecar,
     sidecar_drop_ext,
     skip_bursts,
@@ -1076,6 +1085,7 @@ def export(
         selected = cfg.selected
         selfie = cfg.selfie
         shared = cfg.shared
+        export_aae = cfg.export_aae
         sidecar = cfg.sidecar
         sidecar_drop_ext = cfg.sidecar_drop_ext
         skip_bursts = cfg.skip_bursts
@@ -1645,6 +1655,7 @@ def export(
             + results.exif_updated
             + results.touched
             + results.converted_to_jpeg
+            + results.aae_written
             + results.sidecar_json_written
             + results.sidecar_json_skipped
             + results.sidecar_exiftool_written
@@ -1702,6 +1713,7 @@ def export_photo(
     dest=None,
     verbose=None,
     export_by_date=None,
+    export_aae=None,
     sidecar=None,
     sidecar_drop_ext=False,
     update=None,
@@ -1790,6 +1802,7 @@ def export_photo(
         preview_suffix: str, template to use as suffix for preview images
         replace_keywords: if True, --keyword-template replaces keywords instead of adding keywords
         retry: retry up to retry # of times if there's an error
+        export_aae: bool; if True, will also save adjustments
         sidecar_drop_ext: bool; if True, drops photo extension from sidecar name
         sidecar: list zero, 1 or 2 of ["json","xmp"] of sidecar variety to export
         skip_original_if_edited: bool; if True does not export original if photo has been edited
@@ -1956,6 +1969,7 @@ def export_photo(
                 preview_suffix=rendered_preview_suffix,
                 replace_keywords=replace_keywords,
                 retry=retry,
+                export_aae=export_aae,
                 sidecar_drop_ext=sidecar_drop_ext,
                 sidecar_flags=sidecar_flags,
                 touch_file=touch_file,
@@ -2072,6 +2086,7 @@ def export_photo(
                     preview_suffix=rendered_preview_suffix,
                     replace_keywords=replace_keywords,
                     retry=retry,
+                    export_aae=export_aae,
                     sidecar_drop_ext=sidecar_drop_ext,
                     sidecar_flags=sidecar_flags if not export_original else 0,
                     touch_file=touch_file,
@@ -2159,6 +2174,7 @@ def export_photo_to_directory(
     preview_suffix,
     replace_keywords,
     retry,
+    export_aae,
     sidecar_drop_ext,
     sidecar_flags,
     touch_file,
@@ -2223,6 +2239,7 @@ def export_photo_to_directory(
                 render_options=render_options,
                 replace_keywords=replace_keywords,
                 rich=True,
+                export_aae=export_aae,
                 sidecar=sidecar_flags,
                 sidecar_drop_ext=sidecar_drop_ext,
                 tmpdir=tmpdir,

--- a/osxphotos/photoinfo.py
+++ b/osxphotos/photoinfo.py
@@ -650,28 +650,38 @@ class PhotoInfo:
         return self._info["hasAdjustments"] == 1
 
     @property
-    def adjustments(self):
-        """Returns AdjustmentsInfo class for adjustment data or None if no adjustments; Photos 5+ only"""
+    def adjustments_path(self):
+        """Returns path to adjustments file or none if file doesn't exist"""
         if self._db._db_version <= _PHOTOS_4_VERSION:
             return None
 
-        if self.hasadjustments:
-            try:
-                return self._adjustmentinfo
-            except AttributeError:
-                library = self._db._library_path
-                directory = self._uuid[0]  # first char of uuid
-                plist_file = (
-                    pathlib.Path(library)
-                    / "resources"
-                    / "renders"
-                    / directory
-                    / f"{self._uuid}.plist"
-                )
-                if not plist_file.is_file():
-                    return None
-                self._adjustmentinfo = AdjustmentsInfo(plist_file)
-                return self._adjustmentinfo
+        if not self.hasadjustments:
+            return None
+
+        library = self._db._library_path
+        directory = self._uuid[0]  # first char of uuid
+        plist_file = (
+            pathlib.Path(library)
+            / "resources"
+            / "renders"
+            / directory
+            / f"{self._uuid}.plist"
+        )
+        if not plist_file.is_file():
+            return None
+        return plist_file
+
+    @property
+    def adjustments(self):
+        """Returns AdjustmentsInfo class for adjustment data or None if no adjustments; Photos 5+ only"""
+        try:
+            return self._adjustmentinfo
+        except AttributeError:
+            plist_file = self.adjustments_path
+            if plist_file is None:
+                return None
+            self._adjustmentinfo = AdjustmentsInfo(plist_file)
+            return self._adjustmentinfo
 
     @property
     def external_edit(self):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -604,6 +604,13 @@ CLI_EXPORT_SIDECAR_DROP_EXT_FILENAMES = _normalize_fs_paths(
     ]
 )
 
+CLI_EXPORT_AAE_UUID = "E9BC5C36-7CD1-40A1-A72B-8B8FAC227D51"
+CLI_EXPORT_AAE_FILENAMES = [
+    "wedding.jpg",
+    "wedding.AAE",
+    "wedding_edited.jpeg",
+]
+
 CLI_EXPORT_LIVE = [
     "51F2BEF7-431A-4D31-8AC1-3284A57826AE.jpeg",
     "51F2BEF7-431A-4D31-8AC1-3284A57826AE.mov",
@@ -3356,6 +3363,53 @@ def test_query_deleted_4():
     assert len(json_got) == PHOTOS_IN_TRASH_LEN_15_7
     assert json_got[0]["intrash"]
 
+
+def test_export_aae():
+    """Test export with --export-aae"""
+
+    runner = CliRunner()
+    cwd = os.getcwd()
+    # pylint: disable=not-context-manager
+    with runner.isolated_filesystem():
+        result = runner.invoke(
+            cli_main,
+            [
+                "export",
+                "--db",
+                os.path.join(cwd, CLI_PHOTOS_DB),
+                ".",
+                "--export-aae",
+                f"--uuid={CLI_EXPORT_AAE_UUID}",
+                "-V",
+            ],
+        )
+        assert result.exit_code == 0
+        files = glob.glob("*.*")
+        assert sorted(files) == sorted(CLI_EXPORT_AAE_FILENAMES)
+
+def test_export_aae_as_hardlink():
+    """Test export with --export-aae and --export-as-hardlink"""
+
+    runner = CliRunner()
+    cwd = os.getcwd()
+    # pylint: disable=not-context-manager
+    with isolated_filesystem_here():
+        result = runner.invoke(
+            cli_main,
+            [
+                "export",
+                "--db",
+                os.path.join(cwd, CLI_PHOTOS_DB),
+                ".",
+                "--export-aae",
+                "--export-as-hardlink",
+                f"--uuid={CLI_EXPORT_AAE_UUID}",
+                "-V",
+            ],
+        )
+        assert result.exit_code == 0
+        files = glob.glob("*.*")
+        assert sorted(files) == sorted(CLI_EXPORT_AAE_FILENAMES)
 
 def test_export_sidecar():
     """test --sidecar"""


### PR DESCRIPTION
This adds an option to export adjustment plists as .AAE files, using mostly existing code in osxphotos.

When the export is made with the right options (given in the option help text), Photos.app will import the photos with all adjustments and with the correct thumbnail (importing just the original and the .AAE file results in the unadjusted original being used as a thumbnail).