### PR TITLE
Relax check on google photos takeout

### DIFF
--- a/osxphotos/metadata_reader.py
+++ b/osxphotos/metadata_reader.py
@@ -86,9 +86,8 @@ def get_sidecar_filetype(filepath: str | pathlib.Path) -> SidecarFileType:
                 # could be Google Takeout
                 # Google Takeout JSON appears to have keys:
                 # 'title', 'description', 'imageViews', 'creationTime',
-                # 'photoTakenTime', 'geoData', 'geoDataExif', 'url', 'googlePhotosOrigin'
-                if metadata.get("googlePhotosOrigin"):
-                    return SidecarFileType.GoogleTakeout
+                # 'photoTakenTime', 'geoData', 'geoDataExif', 'url'
+                return SidecarFileType.GoogleTakeout
     return SidecarFileType.Unknown
 
 

--- a/osxphotos/metadata_reader.py
+++ b/osxphotos/metadata_reader.py
@@ -84,10 +84,12 @@ def get_sidecar_filetype(filepath: str | pathlib.Path) -> SidecarFileType:
                     return SidecarFileType.osxphotos
             elif isinstance(metadata, dict):
                 # could be Google Takeout
-                # Google Takeout JSON appears to have keys:
+                # Google Takeout JSON appears to always have keys:
                 # 'title', 'description', 'imageViews', 'creationTime',
                 # 'photoTakenTime', 'geoData', 'geoDataExif', 'url'
-                return SidecarFileType.GoogleTakeout
+                # Google Takeout is the only format to sometimes set 'googlePhotosOrigin'
+                if ('googlePhotosOrigin' in metadata) or all(k in metadata for k in ('title', 'description', 'imageViews', 'creationTime','photoTakenTime', 'geoData', 'geoDataExif', 'url')):
+                    return SidecarFileType.GoogleTakeout
     return SidecarFileType.Unknown
 
 


### PR DESCRIPTION
Found that sidecar files from google takeout not always have the 'googlePhotosOrigin' field.
So I disabled the check. Maybe that's good enough?