### PR TITLE
Import AAE apple video

### DIFF
--- a/osxphotos/cli/import_cli.py
+++ b/osxphotos/cli/import_cli.py
@@ -3415,7 +3415,7 @@ def has_aae(filepaths: Iterable[str | os.PathLike]) -> bool:
 
 
 def has_non_apple_aae(filepaths: Iterable[str | os.PathLike]) -> str | None:
-    """Return truthy value if any file in the list are an AAE file but not an Apple AAE file (external edits)"""
+    """Return True value if any file in the list are an AAE file but not an Apple AAE file (external edits)"""
     for filepath in filepaths:
         filepath = (
             pathlib.Path(filepath)

--- a/osxphotos/image_file_utils.py
+++ b/osxphotos/image_file_utils.py
@@ -118,7 +118,7 @@ def load_aae_file(filepath: str | os.PathLike) -> dict[str, Any] | None:
 def is_apple_photos_aae_file(filepath: str | os.PathLike) -> bool:
     """Return True if filepath is an AAE file containing Apple Photos adjustments; returns False is file contains adjustments for an external editor"""
     if plist := load_aae_file(filepath):
-        if plist.get("adjustmentFormatIdentifier") == "com.apple.photo":
+        if plist.get("adjustmentFormatIdentifier") in ["com.apple.photo", "com.apple.video", ]:
             return True
     return False
 

--- a/tests/README.md
+++ b/tests/README.md
@@ -28,12 +28,14 @@ Some tests require GPU and will look for `OSXPHOTOS_TEST_CONVERT=1`. These will 
 
 A couple of tests require interaction with Photos and configuring a specific test library. Currently these run only on Catalina.  The tests must be specified by using a pytest flag. Only one of these interactive tests can be run at a time.  The current flags are:
 
---addalbum: test --add-to-album options (pytest -vv tests/test_photosalbum_unicode.py tests/test_cli_add_to_album.py --addalbum)
---timewarp: test `osxphotos timewarp` (pytest -vv --timewarp tests/test_cli_timewarp.py)
---test-import: test `osxphotos import` (pytest -vv --test-import tests/test_cli_import.py)
---test-sync: test `osxphotos sync` (pytest -vv --test-sync tests/test_cli_sync.py)
---test-add-locations: test `osxphotos add-locations` (pytest -vv --test-add-locations tests/test_cli_add_locations.py)
---test-batch-edit: test `osxphotos batch-edit` (pytest -vv --test-batch-edit -k batch)
+
+- --addalbum: test --add-to-album options (pytest -vv tests/test_photosalbum_unicode.py tests/test_cli_add_to_album.py --addalbum)
+- --timewarp: test `osxphotos timewarp` (pytest -vv --timewarp tests/test_cli_timewarp.py)
+- --test-import: test `osxphotos import` (pytest -vv --test-import tests/test_cli_import.py)
+- --test-sync: test `osxphotos sync` (pytest -vv --test-sync tests/test_cli_sync.py)
+- --test-add-locations: test `osxphotos add-locations` (pytest -vv 
+--test-add-locations tests/test_cli_add_locations.py)
+- --test-batch-edit: test `osxphotos batch-edit` (pytest -vv --test-batch-edit -k batch)
 
 ## Test Photo Libraries
 


### PR DESCRIPTION
* On import, consider also "com.apple.video" for "adjustmentFormatIdentifier" in plist/AAE.
* Did not run specific import test `--test-import: test osxphotos import (pytest -vv --test-import tests/test_cli_import.py)` -- I may not have the proper setup.
* Simple tests done no my local Library on Monterey.
```
ProductName:    macOS
ProductVersion: 12.7.6
BuildVersion:   21H1320
```
* Small typo fixed on import_cli.py