### PR TITLE
timewarp --inspect and --compare-exif are mutually exclusive. Refactor compare_exif_no_markup and compare_exif_with_markup into timewarp_compare_exif

### DIFF
--- a/osxphotos/cli/timewarp.py
+++ b/osxphotos/cli/timewarp.py
@@ -441,6 +441,9 @@ def timewarp(
             "must be specified."
         )
 
+    if inspect and compare_exif:
+        raise click.UsageError("--inspect and --compare-exif are mutually exclusive.")
+    
     if date and date_delta:
         raise click.UsageError("--date and --date-delta are mutually exclusive.")
 
@@ -600,11 +603,7 @@ def timewarp(
                 )
         for photo in photos:
             set_crash_data("photo", f"{photo.uuid} {photo.filename}")
-            diff_results = (
-                photocomp.compare_exif_no_markup(photo)
-                if plain
-                else photocomp.compare_exif_with_markup(photo)
-            )
+            diff_results = photocomp.timewarp_compare_exif(photo, plain)
 
             if not plain:
                 filename = (


### PR DESCRIPTION
### Changes
Only source code changes included in this PR.
- timewarp --inspect and --compare-exif are mutually exclusive. 
   - **Side note**: Would it be best not to generate osxphotos_crash.log file for such situation (a bit over my level to make that change ;) )
- Refactor compare_exif_no_markup and compare_exif_with_markup into timewarp_compare_exif

### Manual tests `timewarp` pending. See #1693 