### PR TITLE
get_exif_date_time_offset: Prioritize QuickTime:ContentCreateDate over EXIF:DateTimeOriginal for videos.

### DIFF
--- a/osxphotos/exifutils.py
+++ b/osxphotos/exifutils.py
@@ -51,16 +51,28 @@ def get_exif_date_time_offset(
     # set to True if no date/time in EXIF and the FileModifyDate is used
     used_file_modify_date = False
 
+    # determine file type
+    mime_type = exif.get('File:MIMEType', 'image')
+    isphoto = mime_type.startswith("image")
+    ismovie = mime_type.startswith("video")
+
     # search these fields in this order for date/time/timezone
-    time_fields = [
+    # Prioritize QuickTime:ContentCreateDate over EXIF:DateTimeOriginal for videos
+    start_time_fields = [
         "Composite:DateTimeCreated",
         "Composite:SubSecDateTimeOriginal",
         "Composite:SubSecCreateDate",
+    ]
+    photo_time_fields = [
         "EXIF:DateTimeOriginal",
         "EXIF:CreateDate",
+    ]
+    movie_time_fields = [
         "QuickTime:ContentCreateDate",
         "QuickTime:CreationDate",
         "QuickTime:CreateDate",
+    ]
+    end_time_fields = [
         "IPTC:DateCreated",
         "XMP-exif:DateTimeOriginal",
         "XMP-xmp:DateCreated",
@@ -75,11 +87,21 @@ def get_exif_date_time_offset(
         "ContentCreateDate",
         "CreationDate",
     ]
+    if isphoto:
+        time_fields = start_time_fields + photo_time_fields + movie_time_fields + end_time_fields
+    elif ismovie:
+        time_fields = start_time_fields + movie_time_fields + photo_time_fields + end_time_fields
+    else:
+        time_fields = start_time_fields + photo_time_fields + movie_time_fields + end_time_fields
+        
     if use_file_modify_date:
         time_fields.extend(["File:FileModifyDate", "FileModifyDate"])
 
     for dt_str in time_fields:
         dt = exif.get(dt_str)
+        # Some old mp4 may return ContentCreationDate as YYYY (eg. 2014) which
+        # is converted to int causing re.match(pattern, dt) to fail.
+        dt = str(dt) if isinstance(dt, int) else dt
         if dt and dt_str in {"IPTC:DateCreated", "DateCreated"}:
             # also need time
             time_ = exif.get("IPTC:TimeCreated") or exif.get("TimeCreated")


### PR DESCRIPTION
I found some videos (from Canon Cameras) which:
* have EXIF:DateTimeOriginal without offset fields
* and QuickTime:ContentCreateDate with offset.

With this code change we give priority to QuickTime:ContentCreateDate for videos.

PS: maybe not the most elegant code!