### PR TITLE
Protect get_exif_date_time_offset for non-compliant exiftool -OffsetTimeOriginal values, 

### DIFF
--- a/osxphotos/exifutils.py
+++ b/osxphotos/exifutils.py
@@ -119,6 +119,11 @@ def get_exif_date_time_offset(
                 dt = f"{matched.group(1)} 00:00:00"
                 default_time = True
 
+    if offset:
+        # make sure we have offset
+        if not re.match(r"([+-]\d{2}:\d{2})", offset):
+            offset = None
+
     offset_seconds = exif_offset_to_seconds(offset) if offset else None
 
     if dt:


### PR DESCRIPTION
For non-compliant exiftool -OffsetTimeOriginal values, protect get_exif_date_time_offset prior to callingexif_offset_to_seconds. Check if offset matches '+/-hh:mm' format.

Bumped into a JPG from a friend's camera with a value of "  :  " on OffsetTimeOriginal!!!

```py
$ exiftool -a -s -G1 'IMG_20YYMMDD_144722.JPG' | egrep -i "off|model"
[MacOS]         MDItemAcquisitionModel          : E-M10 Mark III
[MacOS]         MDItemFlashOnOff                : 0
[MacOS]         MDItemLensModel                 : Olympus M.Zuiko Digital 45mm F1.8
[MacOS]         MDItemRedEyeOnOff               : 0
[IFD0]          Model                           : E-M10 Mark III
[ExifIFD]       OffsetTime                      :    :
[ExifIFD]       OffsetTimeOriginal              :    :
[ExifIFD]       OffsetTimeDigitized             :    :
[ExifIFD]       LensModel                       : OLYMPUS M.45mm F1.8
```