### PR TITLE
Enhancement #1774: Add option to bypass checking for .osxphotos_export.db in the export folder.

### DIFF
--- a/osxphotos/cli/export.py
+++ b/osxphotos/cli/export.py
@@ -1744,12 +1744,15 @@ def export_cli(
     if not no_exportdb and exportdb and exportdb != str(expected_exportdb):
         if expected_exportdb.exists():
             rich_click_echo(
-                f"[warning]Warning: export database is '{exportdb}' but found '{OSXPHOTOS_EXPORT_DB}' in {dest}; using '{exportdb}'",
+                f"[warning]Warning: export database is '{exportdb}' but found "
+                f"'{OSXPHOTOS_EXPORT_DB}' in {dest}; using '{exportdb}'",
                 err=True,
             )
         if pathlib.Path(exportdb).resolve().parent != pathlib.Path(dest):
             rich_click_echo(
-                f"[warning]Warning: export database '{pathlib.Path(exportdb).resolve()}' is in a different directory than export destination '{dest}'",
+                f"[warning]Warning: export database "
+                f"'{pathlib.Path(exportdb).resolve()}' is in a different "
+                f"directory than export destination '{dest}'",
                 err=True,
             )
 

--- a/osxphotos/cli/export.py
+++ b/osxphotos/cli/export.py
@@ -1771,7 +1771,9 @@ def export_cli(
             return 1
 
     # check that export isn't in the parent or child of a previously exported library
-    if not ignore_exportdb and (other_db_files := find_first_file_in_branch(dest, OSXPHOTOS_EXPORT_DB)):
+    if not ignore_exportdb and (
+        other_db_files := find_first_file_in_branch(dest, OSXPHOTOS_EXPORT_DB)
+    ):
         rich_click_echo(
             "[warning]WARNING: found other export database files in this destination directory branch. "
             "This likely means you are attempting to export files into a directory "
@@ -3002,11 +3004,11 @@ def get_dirnames_from_template(
 
 
 def find_first_file_in_branch(pathname, filename):
-    """Search a directory branch to find file(s) named filename
-        The branch searched includes all folders below pathname and
-        the parent tree of pathname but not pathname itself.
+    """Search a directory branch to find file(s) named filename.
+       The branch searched includes all folders below pathname and
+       the parent tree of pathname but not pathname itself.
 
-        e.g. find filename in children folders and parent folders
+       e.g. find filename in children folders and parent folders
 
     Args:
         pathname: str, full path of directory to search
@@ -3016,14 +3018,12 @@ def find_first_file_in_branch(pathname, filename):
     """
 
     pathname = pathlib.Path(pathname).resolve()
-    files = []
 
     # walk down the tree
     for root, _, filenames in os.walk(pathname):
-        # for directory in directories:
         for fname in filenames:
             if fname == filename and pathlib.Path(root) != pathname:
-                files.append(os.path.join(root, fname))
+                return [os.path.join(root, fname)]
 
     # walk up the tree
     path = pathlib.Path(pathname)
@@ -3032,9 +3032,9 @@ def find_first_file_in_branch(pathname, filename):
         for fname in filenames:
             filepath = os.path.join(root, fname)
             if fname == filename and os.path.isfile(filepath):
-                files.append(os.path.join(root, fname))
+                return [filepath]
 
-    return files
+    return []
 
 
 def collect_files_to_keep(

--- a/osxphotos/cli/export.py
+++ b/osxphotos/cli/export.py
@@ -1777,20 +1777,18 @@ def export_cli(
 
     # check that export isn't in the parent or child of a previously exported library
     if not (ignore_exportdb or exportdb or no_exportdb) and (
-        other_db_files := find_first_file_in_branch(dest, OSXPHOTOS_EXPORT_DB)
+        other_db_file := find_first_file_in_branch(dest, OSXPHOTOS_EXPORT_DB)
     ):
         rich_click_echo(
-            "[warning]WARNING: found other export database files in this destination directory branch. "
+            "[warning]WARNING: found other export database file in this destination directory branch. "
             "This likely means you are attempting to export files into a directory "
             "that is either the parent or a child directory of a previous export. "
             "Proceeding may cause your exported files to be overwritten.",
             err=True,
         )
         rich_click_echo(
-            f"You are exporting to {dest}, found {OSXPHOTOS_EXPORT_DB} files in:"
+            f"You are exporting to {dest}, found {OSXPHOTOS_EXPORT_DB} file in: {other_db_file}"
         )
-        for other_db in other_db_files:
-            rich_click_echo(f"{other_db}")
         if not click.confirm("Do you want to continue?"):
             return 1
 
@@ -3028,7 +3026,7 @@ def find_first_file_in_branch(pathname, filename):
     for root, _, filenames in os.walk(pathname):
         for fname in filenames:
             if fname == filename and pathlib.Path(root) != pathname:
-                return [os.path.join(root, fname)]
+                return os.path.join(root, fname)
 
     # walk up the tree
     path = pathlib.Path(pathname)
@@ -3037,9 +3035,9 @@ def find_first_file_in_branch(pathname, filename):
         for fname in filenames:
             filepath = os.path.join(root, fname)
             if fname == filename and os.path.isfile(filepath):
-                return [filepath]
+                return filepath
 
-    return []
+    return None
 
 
 def collect_files_to_keep(

--- a/osxphotos/cli/export.py
+++ b/osxphotos/cli/export.py
@@ -1767,11 +1767,16 @@ def export_cli(
             "Please confirm that you want to continue without using --update",
             err=True,
         )
-        if not ignore_exportdb and not click.confirm("Do you want to continue?"):
+        if ignore_exportdb:
+            rich_click_echo(
+                "[warning]Warning: option --ignore-exportdb enabled: ignoring export database; "
+                "osxphotos will not consider state of previous export which may result in duplicate files."
+            )
+        elif not click.confirm("Do you want to continue?"):
             return 1
 
     # check that export isn't in the parent or child of a previously exported library
-    if not ignore_exportdb and (
+    if not (ignore_exportdb or exportdb or no_exportdb) and (
         other_db_files := find_first_file_in_branch(dest, OSXPHOTOS_EXPORT_DB)
     ):
         rich_click_echo(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -5623,7 +5623,7 @@ def test_export_update_child_folder():
             input="N\n",
         )
         assert result.exit_code != 0
-        assert "WARNING: found other export database files" in result.output
+        assert "WARNING: found other export database file" in result.output
 
 
 def test_export_update_parent_folder():
@@ -5647,7 +5647,7 @@ def test_export_update_parent_folder():
             input="N\n",
         )
         assert result.exit_code != 0
-        assert "WARNING: found other export database files" in result.output
+        assert "WARNING: found other export database file" in result.output
 
 
 @pytest.mark.skipif(exiftool is None, reason="exiftool not installed")


### PR DESCRIPTION
Enhancement #1774: Add option to bypass checking for .osxphotos_export.db in the export folder.

* Reusing option --ignore-exportdb.
* Removed exclusivity of options --update and --ignore-exportdb.
* Search for exportdb files logic will also **not be done** if options --exportdb or --no-exportdb are used. No matter the use or not of --ignore-exportdb.
* Adjusted option definition. Maybe a bit lengthy 😞 !
* Renamed function find_files_in_branch into find_first_file_in_branch and revised logic to return on first occurrence found, when --ignore-exportdb is not active.
* When --ignore-exportdb is used without --update added warnings osxphotos will continue to make it compatible with interactive questions presented.