### PR TITLE
Fix photo timezone logging accuracy

### DIFF
--- a/osxphotos/phototz.py
+++ b/osxphotos/phototz.py
@@ -181,9 +181,10 @@ class PhotoTimeZoneUpdater:
             photo.date = photo.date - datetime.timedelta(seconds=1)
 
             self.verbose(
-                f"Updated timezone for photo [filename]{photo.filename}[/filename] ([uuid]{photo.uuid}[/uuid]) "
-                + f"from [tz]{tz_name}[/tz], offset=[tz]{tz_offset}[/tz] "
-                + f"to [tz]{self.tz_name}[/tz], offset=[tz]{self.tz_offset}[/tz]"
+                f"Updated timezone for photo "
+                f"[filename]{photo.filename}[/filename] ([uuid]{photo.uuid}[/uuid]) "
+                f"from [tz]{tz_name}[/tz], offset=[tz]{tz_offset}[/tz] "
+                f"to [tz]{self.tz_name}[/tz], offset=[tz]{photo_tz_offset}[/tz]"
             )
         except Exception as e:
             raise e

--- a/osxphotos/phototz.py
+++ b/osxphotos/phototz.py
@@ -181,7 +181,7 @@ class PhotoTimeZoneUpdater:
             photo.date = photo.date - datetime.timedelta(seconds=1)
 
             self.verbose(
-                f"Updated timezone for photo "
+                "Updated timezone for photo "
                 f"[filename]{photo.filename}[/filename] ([uuid]{photo.uuid}[/uuid]) "
                 f"from [tz]{tz_name}[/tz], offset=[tz]{tz_offset}[/tz] "
                 f"to [tz]{self.tz_name}[/tz], offset=[tz]{photo_tz_offset}[/tz]"


### PR DESCRIPTION
Update logging to correctly reflect the photo's timezone offset and improve the message format for clarity.