### PR TITLE
feat(import): add skipped and duplicate_of fields to import report

### DIFF
--- a/osxphotos/cli/import_cli.py
+++ b/osxphotos/cli/import_cli.py
@@ -2291,6 +2291,8 @@ class ReportRecord:
     title: str = ""
     uuid: str = ""
     datetime: datetime.datetime | None = None
+    skipped: bool = False
+    duplicate_of: str = ""  # UUID of duplicate photo in library when skipped
 
     @classmethod
     def serialize(cls, record: "ReportRecord") -> str:
@@ -3195,6 +3197,8 @@ def import_files(
                         verbose(f"Skipping duplicate [filename]{filepath.name}[/]")
                         skipped_count += 1
                         report_record.imported = False
+                        report_record.skipped = True
+                        report_record.duplicate_of = duplicates[0][0]  # UUID of first duplicate
 
                         if not dup_albums:
                             continue


### PR DESCRIPTION
## Summary

When using `--skip-dups`, the import report JSON now includes two new fields:
- `skipped`: `true` when a file was intentionally skipped as a duplicate (vs failed to import)
- `duplicate_of`: UUID of the existing photo in the Photos library that matched

## Problem

Currently, when `--skip-dups` causes a file to be skipped, the report only shows:
```json
{
  "imported": false,
  "error": false,
  "uuid": ""
}
```

There's no way to distinguish between:
1. A file that was skipped because it's a duplicate
2. A file that failed to import for another reason

And no way to recover the UUID of the existing duplicate photo.

## Solution

Add two fields to `ReportRecord`:
- `skipped: bool = False`
- `duplicate_of: str = ""`

When a duplicate is detected and skipped:
```json
{
  "imported": false,
  "error": false,
  "uuid": "",
  "skipped": true,
  "duplicate_of": "UUID-OF-EXISTING-PHOTO"
}
```

## Use Case

I'm building a photo migration tool that imports from Google Takeout to Photos.app. When resuming interrupted imports or handling files that were already imported via iCloud sync, I need to:
1. Know which files were skipped as duplicates (vs failed)
2. Recover the UUID of the existing photo for tracking/verification

This 4-line change enables that workflow.

## Test Plan

- [ ] Manual test: Run import with `--skip-dups --report report.json` on files with known duplicates
- [ ] Verify JSON report contains `skipped: true` and `duplicate_of: <uuid>` for skipped files
- [ ] Verify existing behavior unchanged for non-duplicate imports