### PR TITLE
Fix file descriptor leak in PhotosDB.execute()

### DIFF
--- a/osxphotos/photosdb/photosdb.py
+++ b/osxphotos/photosdb/photosdb.py
@@ -3294,7 +3294,8 @@ class PhotosDB:
 
     def execute(self, sql: str, params: Any | None = None) -> sqlite3.Cursor:
         """Execute sql statement and return cursor"""
-        self._db_connection, _ = self.get_db_connection()
+        if not getattr(self, "_db_connection", None):
+            self._db_connection, _ = self.get_db_connection()
         params = params or ()
         return self._db_connection.cursor().execute(sql, params)
 


### PR DESCRIPTION
execute() opens a new SQLite connection via get_db_connection() on every call, without closing the previous one. On large libraries, serializing to JSON triggers tens of thousands of leaked connections, exhausting the OS file descriptor limit and crashing with "unable to open database file".

Reuse the existing _db_connection if one is already open. Uses getattr() because execute() can be called during _process_database5() before _db_connection is initialized in __init__.