### PR TITLE
fix(text_detection): remove manual .dealloc() calls causing SIGSEGV

### DIFF
--- a/osxphotos/text_detection.py
+++ b/osxphotos/text_detection.py
@@ -70,8 +70,6 @@ def detect_text(img_path: str, orientation: Optional[int] = None) -> List:
             Vision.VNRecognizeTextRequest.alloc().initWithCompletionHandler_(handler)
         )
         error = vision_handler.performRequests_error_([vision_request], None)
-        vision_request.dealloc()
-        vision_handler.dealloc()
 
         for result in results:
             result[0] = str(result[0])


### PR DESCRIPTION
Fixes #2143.

## What

Removes two `.dealloc()` calls in `osxphotos/text_detection.py` that were causing `SIGSEGV` crashes inside Apple's Vision framework during text detection.

```diff
         error = vision_handler.performRequests_error_([vision_request], None)
-        vision_request.dealloc()
-        vision_handler.dealloc()
```

## Why

PyObjC uses automatic memory management. Calling `.dealloc()` manually on `VNRecognizeTextRequest` / `VNImageRequestHandler` clears the underlying Cocoa objects while Vision's internal dispatch block still retains a reference. The block later releases its captured pointer to freed memory, crashing inside `-[VNRequestPerformingContext .cxx_destruct]`.

PyObjC maintainer Ronald Oussoren confirmed this pattern in [pyobjc#591](https://github.com/ronaldoussoren/pyobjc/issues/591):

> Don't call `req.dealloc()` and `handler.dealloc()`, those will clear the memory of these objects regardless of the number of references. Cocoa uses automatic memory management like Python and you don't have to manage memory manually.

The surrounding `with objc.autorelease_pool():` block already handles memory correctly; these explicit `.dealloc()` calls were redundant and actively harmful.

## Verification

Tested on osxphotos 0.75.1 / macOS 26.5 / PyObjC 12.1.

**Before:** `night_janitor analyze --limit 500 --newest` crashed with `SIGSEGV` within 8 seconds of entering the analyze loop.

**After:** Same command, same photo batch, clean completion:

```
Analyzed 500 photos
Category Breakdown:
  SCREENSHOT: 59
  DOCUMENT: 52
  RECEIPT: 1
  ...
EXIT: 0
```

`SCREENSHOT`, `DOCUMENT`, and `RECEIPT` classifications all exercise `photo.detected_text()` — the exact call path that was crashing.

See #2143 for full crash report (`.ips` file) and backtrace.
