### PR TITLE
Fix: FingerprintQuery fails when Photos.sqlite is locked

### DIFF
--- a/osxphotos/fingerprintquery.py
+++ b/osxphotos/fingerprintquery.py
@@ -5,7 +5,9 @@ from __future__ import annotations
 import datetime
 import os
 import pathlib
+import shutil
 import sqlite3
+import tempfile
 
 from ._constants import _DB_TABLE_NAMES
 from .fingerprint import fingerprint
@@ -31,8 +33,29 @@ class FingerprintQuery:
             # assume path to root of Photos library
             # if not, assume it's the path to the Photos.sqlite file
             self.photos_library = self.photos_library / "database" / "Photos.sqlite"
-        self.conn = sqlite3.connect(str(self.photos_library))
+        # Photos.app's photolibraryd holds an exclusive lock on Photos.sqlite
+        # even after Photos.app quits, so copy the db (and its -wal/-shm
+        # companions) to a temp dir before opening. This mirrors the pattern
+        # used by PhotosDB._copy_db_file.
+        self._tmpdir = tempfile.TemporaryDirectory(prefix="osxphotos_fpq_")
+        tmp_db = os.path.join(self._tmpdir.name, self.photos_library.name)
+        shutil.copyfile(str(self.photos_library), tmp_db)
+        for suffix in ("-wal", "-shm"):
+            src = str(self.photos_library) + suffix
+            if os.path.exists(src):
+                shutil.copyfile(src, tmp_db + suffix)
+        self.conn = sqlite3.connect(tmp_db)
         self.photos_version = get_photos_version_from_model(str(self.photos_library))
+
+    def __del__(self):
+        try:
+            self.conn.close()
+        except Exception:
+            pass
+        try:
+            self._tmpdir.cleanup()
+        except Exception:
+            pass
 
     def photos_by_fingerprint(
         self, fingerprint: str, in_trash: bool = False

--- a/osxphotos/fingerprintquery.py
+++ b/osxphotos/fingerprintquery.py
@@ -1,18 +1,16 @@
-"""Query Photos database for photos matching fingerprint """
+"""Query Photos database for photos matching fingerprint"""
 
 from __future__ import annotations
 
 import datetime
 import os
 import pathlib
-import shutil
-import sqlite3
-import tempfile
 
 from ._constants import _DB_TABLE_NAMES
 from .fingerprint import fingerprint
 from .photos_datetime import photos_datetime
 from .photosdb.photosdb_utils import get_photos_version_from_model
+from .sqlite_utils import sqlite_open_ro_with_temp_copy
 
 
 class FingerprintQuery:
@@ -33,27 +31,13 @@ class FingerprintQuery:
             # assume path to root of Photos library
             # if not, assume it's the path to the Photos.sqlite file
             self.photos_library = self.photos_library / "database" / "Photos.sqlite"
-        # Photos.app's photolibraryd holds an exclusive lock on Photos.sqlite
-        # even after Photos.app quits, so copy the db (and its -wal/-shm
-        # companions) to a temp dir before opening. This mirrors the pattern
-        # used by PhotosDB._copy_db_file.
-        self._tmpdir = tempfile.TemporaryDirectory(prefix="osxphotos_fpq_")
-        tmp_db = os.path.join(self._tmpdir.name, self.photos_library.name)
-        shutil.copyfile(str(self.photos_library), tmp_db)
-        for suffix in ("-wal", "-shm"):
-            src = str(self.photos_library) + suffix
-            if os.path.exists(src):
-                shutil.copyfile(src, tmp_db + suffix)
-        self.conn = sqlite3.connect(tmp_db)
-        self.photos_version = get_photos_version_from_model(str(self.photos_library))
+        self.conn, _ = sqlite_open_ro_with_temp_copy(self.photos_library)
+        db_path = self.conn.execute("PRAGMA database_list").fetchone()[2]
+        self.photos_version = get_photos_version_from_model(db_path)
 
     def __del__(self):
         try:
             self.conn.close()
-        except Exception:
-            pass
-        try:
-            self._tmpdir.cleanup()
         except Exception:
             pass
 

--- a/osxphotos/sqlite_utils.py
+++ b/osxphotos/sqlite_utils.py
@@ -25,6 +25,7 @@ __all__ = [
     "sqlite_delete_backup_files",
     "sqlite_delete_dbfiles",
     "sqlite_open_ro",
+    "sqlite_open_ro_with_temp_copy",
     "sqlite_recover_db",
     "sqlite_repair_db",
     "sqlite_tables",
@@ -37,7 +38,25 @@ def get_sqlite_cli() -> str:
     return shutil.which("sqlite3")
 
 
-def sqlite_open_ro(dbname: str) -> Tuple[sqlite3.Connection, sqlite3.Cursor]:
+class _SQLiteTempCopyConnection(sqlite3.Connection):
+    """sqlite3 connection that cleans up an associated temporary directory."""
+
+    _tempdir: tempfile.TemporaryDirectory | None = None
+
+    def close(self) -> None:
+        """Close connection and clean up temporary database copy."""
+        try:
+            super().close()
+        finally:
+            if self._tempdir is not None:
+                self._tempdir.cleanup()
+                self._tempdir = None
+
+
+def _sqlite_open_ro(
+    dbname: str | pathlib.Path,
+    factory: type[sqlite3.Connection] = sqlite3.Connection,
+) -> Tuple[sqlite3.Connection, sqlite3.Cursor]:
     """opens sqlite file dbname in read-only mode
     returns tuple of (connection, cursor)"""
     try:
@@ -47,6 +66,7 @@ def sqlite_open_ro(dbname: str) -> Tuple[sqlite3.Connection, sqlite3.Cursor]:
             timeout=1,
             uri=True,
             check_same_thread=SQLITE_CHECK_SAME_THREAD,
+            factory=factory,
         )
         c = conn.cursor()
     except sqlite3.Error as e:
@@ -54,6 +74,53 @@ def sqlite_open_ro(dbname: str) -> Tuple[sqlite3.Connection, sqlite3.Cursor]:
             f"An error occurred opening sqlite file: {e} {dbname}"
         ) from e
     return (conn, c)
+
+
+def sqlite_open_ro(
+    dbname: str | pathlib.Path,
+) -> Tuple[sqlite3.Connection, sqlite3.Cursor]:
+    """opens sqlite file dbname in read-only mode
+    returns tuple of (connection, cursor)"""
+    return _sqlite_open_ro(dbname)
+
+
+def _sqlite_temp_copy_dbfiles(
+    dbpath: str | pathlib.Path, tempdir: tempfile.TemporaryDirectory
+) -> pathlib.Path:
+    """Copy sqlite database files to tempdir and return copied database path."""
+    dbpath = pathlib.Path(dbpath)
+    fileutil = FileUtilMacOS if is_macos else FileUtil
+    temp_dbpath = pathlib.Path(tempdir.name) / dbpath.name
+    for suffix in ["", "-wal", "-shm"]:
+        src = pathlib.Path(f"{dbpath}{suffix}")
+        if not src.exists():
+            continue
+        dst = pathlib.Path(f"{temp_dbpath}{suffix}")
+        fileutil.copy(src, dst)
+    return temp_dbpath
+
+
+def sqlite_open_ro_with_temp_copy(
+    dbname: str | pathlib.Path,
+) -> Tuple[sqlite3.Connection, sqlite3.Cursor]:
+    """Open sqlite file dbname in read-only mode, copying to temp if locked.
+
+    If dbname is locked, copies dbname and any associated -wal/-shm files to a
+    temporary directory before opening the copied database read-only. The
+    temporary directory is cleaned up when the returned connection is closed.
+    """
+    if not sqlite_db_is_locked(dbname):
+        return sqlite_open_ro(dbname)
+
+    tempdir = tempfile.TemporaryDirectory(prefix="osxphotos_sqlite_")
+    temp_dbpath = _sqlite_temp_copy_dbfiles(dbname, tempdir)
+    try:
+        conn, cursor = _sqlite_open_ro(temp_dbpath, factory=_SQLiteTempCopyConnection)
+    except Exception:
+        tempdir.cleanup()
+        raise
+    conn._tempdir = tempdir
+    return conn, cursor
 
 
 def sqlite_db_is_locked(dbname: str | pathlib.Path) -> bool:

--- a/tests/test_sqlite_utils.py
+++ b/tests/test_sqlite_utils.py
@@ -1,10 +1,18 @@
-"""Tests for sqlite_utils """
+"""Tests for sqlite_utils"""
 
+import pathlib
+import shutil
 import sqlite3
+import tempfile
 
 import pytest
 
-from osxphotos.sqlite_utils import sqlite_db_is_locked, sqlite_open_ro
+import osxphotos.sqlite_utils as sqlite_utils
+from osxphotos.sqlite_utils import (
+    sqlite_db_is_locked,
+    sqlite_open_ro,
+    sqlite_open_ro_with_temp_copy,
+)
 
 DB_UNLOCKED_10_15 = "./tests/Test-10.15.1.photoslibrary/database/photos.db"
 
@@ -18,3 +26,56 @@ def test_open_sqlite_ro():
     assert isinstance(conn, sqlite3.Connection)
     assert isinstance(cur, sqlite3.Cursor)
     conn.close()
+
+
+def test_open_sqlite_ro_with_temp_copy_if_locked(tmp_path, monkeypatch):
+    db_path = tmp_path / "test.sqlite"
+    conn = sqlite3.connect(db_path)
+    conn.execute("CREATE TABLE test_table (value TEXT)")
+    conn.execute("INSERT INTO test_table VALUES ('test')")
+    conn.commit()
+    conn.close()
+
+    monkeypatch.setattr(sqlite_utils, "sqlite_db_is_locked", lambda _: True)
+
+    conn, cur = sqlite_open_ro_with_temp_copy(db_path)
+    temp_db = pathlib.Path(conn.execute("PRAGMA database_list").fetchone()[2])
+
+    assert temp_db != db_path.resolve()
+    assert cur.execute("SELECT value FROM test_table").fetchone()[0] == "test"
+    with pytest.raises(sqlite3.OperationalError):
+        conn.execute("INSERT INTO test_table VALUES ('readonly')")
+
+    conn.close()
+    assert not temp_db.exists()
+
+
+def test_sqlite_temp_copy_dbfiles_copies_associated_files(tmp_path, monkeypatch):
+    class CopyUtil:
+        @classmethod
+        def copy(cls, src, dst):
+            copied.append((pathlib.Path(src).name, pathlib.Path(dst).name))
+            shutil.copyfile(src, dst)
+
+    copied = []
+    db_path = tmp_path / "test.sqlite"
+    for suffix in ["", "-wal", "-shm"]:
+        pathlib.Path(f"{db_path}{suffix}").write_text(f"data{suffix}")
+
+    monkeypatch.setattr(sqlite_utils, "is_macos", False)
+    monkeypatch.setattr(sqlite_utils, "FileUtil", CopyUtil)
+
+    tempdir = tempfile.TemporaryDirectory()
+    try:
+        temp_db = sqlite_utils._sqlite_temp_copy_dbfiles(db_path, tempdir)
+
+        assert temp_db == pathlib.Path(tempdir.name) / db_path.name
+        assert pathlib.Path(f"{temp_db}-wal").read_text() == "data-wal"
+        assert pathlib.Path(f"{temp_db}-shm").read_text() == "data-shm"
+        assert copied == [
+            ("test.sqlite", "test.sqlite"),
+            ("test.sqlite-wal", "test.sqlite-wal"),
+            ("test.sqlite-shm", "test.sqlite-shm"),
+        ]
+    finally:
+        tempdir.cleanup()


### PR DESCRIPTION
# Fix: `FingerprintQuery` fails with "unable to open database file" when Photos.app is active

## Summary

`osxphotos import` crashes with `sqlite3.OperationalError: unable to open
database file` during the fingerprint-based duplicate check whenever
`photolibraryd` has `Photos.sqlite` attached (i.e. whenever Photos.app or its
background helpers are running — which is essentially always, since
`photolibraryd` keeps the library mounted for the Memories, face analysis, and
similar services even after Photos.app is quit).

This makes `osxphotos import` practically unusable on a system that has ever
opened Photos.app with the target library, including the common case of
importing into an existing library.

## Root cause

`FingerprintQuery.__init__` opens Photos.sqlite with a plain
`sqlite3.connect(str(path))`, which respects OS-level locks. `photolibraryd`
holds an exclusive lock on Photos.sqlite, so this connection fails.

The rest of osxphotos sidesteps this by making a temporary copy of
`Photos.sqlite` (and its `-wal`/`-shm` companions) before opening — see
`PhotosDB._copy_db_file` in `photosdb/photosdb.py`, with the explanatory
comment:

```python
# required because python's sqlite3 implementation can't read a locked file
```

`FingerprintQuery` is the one place that doesn't do this.

## Fix

Apply the same copy-first pattern in `FingerprintQuery.__init__`:

- Copy `Photos.sqlite` (plus `-wal` and `-shm` if present) into a
  `tempfile.TemporaryDirectory`.
- Open the copy with `sqlite3.connect`.
- Clean up the temp dir in `__del__`.

The patch is ~15 lines in a single file (`osxphotos/fingerprintquery.py`) with
no API changes and no test-surface changes.

## Reproduction

```bash
# 1. Open Photos.app with some library, then quit it. photolibraryd keeps
#    the library locked in the background.
# 2. Run import:
osxphotos import /path/to/exported/photos --sidecar --walk --verbose
```

Expected: import proceeds.
Actual (before fix): `OperationalError: unable to open database file` in
`fingerprintquery.py:58` (`photos_by_fingerprint`), called from
`import_cli.py:3191` (`import_files`).

## Verification

With the patch applied, confirmed end-to-end against a live-locked library:

- Target: freshly-created empty Photos library on an external volume
  (`photolibraryd` attached and holding Photos.sqlite).
- Input: 15 exported images (originals + edited versions) with XMP sidecars.
- Result: `Done: imported 8 file groups, 0 errors`. All dates/metadata set
  correctly from sidecars. No SQLite errors.

## Related finding (separate repo, separate issue)

While verifying end-to-end, a second independent bug surfaced in
[`photoscript`](https://github.com/RhetTbull/photoscript):
`photosLibraryWaitForPhotos` in `photoscript.applescript` only returns `true`
when `(count of media items) > 0`, which means it times out with
`error number -128` when importing into an empty library. Workaround: keep
Photos.app open with the target library before invoking `osxphotos import`.
That's out of scope for this PR but worth tracking as a separate issue in the
photoscript repo.

## Audit: other read-only SELECTs against Photos.sqlite

A broader scan for the same pattern finds a few other plain `sqlite3.connect`
call sites against Photos.sqlite that look read-only and may be affected by
the same issue. They are not in the `osxphotos import` hot path so are not
addressed here, but flagging for a possible follow-up pass:

- `photodates.py:593, 690` — SELECT-only queries.
- `cli/dbversion.py:18` — reads schema objects.

(Write-path uses in `phototz.py` and the UPDATE statements in `photodates.py`
correctly require the caller to have Photos.app closed and are out of scope.)
