### PR TITLE
Bound PhotoKit requests with a timeout (fix indefinite hang when an iCloud callback never fires)

### DIFF
--- a/osxphotos/photokit.py
+++ b/osxphotos/photokit.py
@@ -18,6 +18,7 @@
 # make burst/live methods get uuid from self instead of passing as arg
 
 import copy
+import os
 import pathlib
 import sys
 import threading
@@ -186,10 +187,47 @@ class PhotoKitExportError(PhotoKitError):
     pass
 
 
+class PhotoKitTimeoutError(PhotoKitError):
+    """Raised when an asynchronous PhotoKit request exceeds PHOTOKIT_REQUEST_TIMEOUT.
+
+    PhotoKit image/resource/video requests are asynchronous and set
+    networkAccessAllowed=True, so they may try to download originals from iCloud.
+    If iCloud stalls, the completion/result handler never fires and the request
+    would otherwise block the calling thread forever. This bounds that wait.
+    """
+
+    pass
+
+
 class PhotoKitMediaTypeError(PhotoKitError):
     """Exception raised if an unknown mediaType() is encountered"""
 
     pass
+
+
+# Maximum seconds to wait for an asynchronous PhotoKit request (image / resource / video
+# data) before raising PhotoKitTimeoutError. These requests set networkAccessAllowed=True,
+# so a stalled iCloud download can otherwise block the calling thread INDEFINITELY -- the
+# result/completion handler simply never fires. A per-request bound prevents that hang.
+# The default (300s) is generous for a real iCloud download, even a large video, while still
+# catching a true stall. Override with the OSXPHOTOS_PHOTOKIT_TIMEOUT environment variable;
+# set it to 0 to restore the legacy "wait forever" behavior.
+PHOTOKIT_REQUEST_TIMEOUT = float(os.environ.get("OSXPHOTOS_PHOTOKIT_TIMEOUT") or 300)
+
+
+def _wait_for_event_or_timeout(event, asset_id):
+    """Block on a PhotoKit completion event, bounded by PHOTOKIT_REQUEST_TIMEOUT.
+
+    PhotoKit image/resource/video requests are asynchronous; the result/completion handler
+    sets ``event``. If iCloud stalls and the handler never fires, an unbounded wait would
+    block the calling thread forever, so the wait is bounded and PhotoKitTimeoutError is
+    raised. A PHOTOKIT_REQUEST_TIMEOUT of 0 restores the legacy "wait forever" behavior.
+    """
+    if not event.wait(PHOTOKIT_REQUEST_TIMEOUT or None):
+        raise PhotoKitTimeoutError(
+            f"PhotoKit request timed out after {PHOTOKIT_REQUEST_TIMEOUT}s for asset "
+            f"{asset_id} (the iCloud download may have stalled)"
+        )
 
 
 ### helper classes
@@ -659,7 +697,7 @@ class PhotoAsset:
             self._manager.requestImageDataAndOrientationForAsset_options_resultHandler_(
                 self.phasset, options_request, handler
             )
-            event.wait()
+            _wait_for_event_or_timeout(event, self.phasset.localIdentifier())
             # options_request.dealloc()
 
             # not sure why this is needed -- some weird ref count thing maybe
@@ -705,7 +743,7 @@ class PhotoAsset:
                 resource, options, handler, completion_handler
             )
 
-            event.wait()
+            _wait_for_event_or_timeout(event, self.phasset.localIdentifier())
 
             # not sure why this is needed -- some weird ref count thing maybe
             # if I don't do this, memory leaks
@@ -985,7 +1023,7 @@ class VideoAsset(PhotoAsset):
             self._manager.requestAVAssetForVideo_options_resultHandler_(
                 self.phasset, options_request, handler
             )
-            event.wait()
+            _wait_for_event_or_timeout(event, self.phasset.localIdentifier())
 
             # not sure why this is needed -- some weird ref count thing maybe
             # if I don't do this, memory leaks

--- a/tests/test_photokit_timeout.py
+++ b/tests/test_photokit_timeout.py
@@ -1,0 +1,55 @@
+"""Tests for the PhotoKit request timeout (PHOTOKIT_REQUEST_TIMEOUT / PhotoKitTimeoutError).
+
+These tests exercise the timeout helper directly and need no Photos library or network:
+they reproduce the exact failure mode (an async PhotoKit request whose completion handler
+never fires, e.g. a stalled iCloud download) and assert the wait is bounded rather than
+blocking the calling thread forever.
+"""
+
+import threading
+import time
+
+import pytest
+
+from osxphotos import photokit
+from osxphotos.photokit import PhotoKitTimeoutError, _wait_for_event_or_timeout
+
+
+def test_timeout_raises_when_handler_never_fires(monkeypatch):
+    """Stalled handler (event never set) -> PhotoKitTimeoutError, bounded by the timeout."""
+    monkeypatch.setattr(photokit, "PHOTOKIT_REQUEST_TIMEOUT", 0.2)
+    event = threading.Event()  # never set -> simulates a stalled iCloud callback
+    start = time.monotonic()
+    with pytest.raises(PhotoKitTimeoutError):
+        _wait_for_event_or_timeout(event, "TEST-ASSET-ID")
+    elapsed = time.monotonic() - start
+    # returned at ~the timeout, not hung forever
+    assert 0.15 < elapsed < 2.0
+
+
+def test_returns_when_handler_fires(monkeypatch):
+    """Handler fired (event set) -> returns without raising."""
+    monkeypatch.setattr(photokit, "PHOTOKIT_REQUEST_TIMEOUT", 5.0)
+    event = threading.Event()
+    event.set()
+    assert _wait_for_event_or_timeout(event, "TEST-ASSET-ID") is None
+
+
+def test_zero_timeout_restores_wait_forever(monkeypatch):
+    """PHOTOKIT_REQUEST_TIMEOUT == 0 restores legacy 'wait forever' behavior.
+
+    (A set event is used so the test itself does not block; the point is that 0 maps to
+    Event.wait(None) rather than to a zero-second poll.)
+    """
+    monkeypatch.setattr(photokit, "PHOTOKIT_REQUEST_TIMEOUT", 0)
+    event = threading.Event()
+    event.set()
+    assert _wait_for_event_or_timeout(event, "TEST-ASSET-ID") is None
+
+
+def test_error_message_includes_asset_id(monkeypatch):
+    """The raised error names the asset, to aid debugging a real stall."""
+    monkeypatch.setattr(photokit, "PHOTOKIT_REQUEST_TIMEOUT", 0.1)
+    event = threading.Event()
+    with pytest.raises(PhotoKitTimeoutError, match="TEST-ASSET-ID"):
+        _wait_for_event_or_timeout(event, "TEST-ASSET-ID")

--- a/tests/test_photokit_timeout.py
+++ b/tests/test_photokit_timeout.py
@@ -11,9 +11,14 @@ import time
 
 import pytest
 
-from osxphotos import photokit
-from osxphotos.photokit import PhotoKitTimeoutError, _wait_for_event_or_timeout
+from osxphotos.platform import is_macos
 
+if is_macos:
+    from osxphotos import photokit
+    from osxphotos.photokit import PhotoKitTimeoutError, _wait_for_event_or_timeout
+else:
+    pytest.skip(allow_module_level=True, reason="Tests only run on macOS")
+    
 
 def test_timeout_raises_when_handler_never_fires(monkeypatch):
     """Stalled handler (event never set) -> PhotoKitTimeoutError, bounded by the timeout."""


### PR DESCRIPTION
Rhet, thanks for all the great work. I've been using osxphotos for years "in semi-production" to process all my
screenshots for years — but only sporadically, because of how long it sometimes ran. 

With the help of Claude Code, I let it run overnight, looping through all the permutations to come up with a
reproduction. It's all documented below, and here's a proposed PR that introduces a timeout to
**osxphotos's asynchronous PhotoKit data requests (`osxphotos/photokit.py`)**, so they can't block
forever when an iCloud download stalls.

This is now what I'm using for a daily `launchd` job that copies screenshots to Google Cloud Storage.

The complete experiment logs are below, along with the proposed change rationale. Please let me know
what you think.

Cheers!
Gene

*The rest is written by Claude Code.*

---

## TL;DR
`PhotoAsset`/`VideoAsset` request image, resource, and video data via async PhotoKit calls and block
on a `threading.Event().wait()` with **no timeout**. Those requests set `networkAccessAllowed=True`,
so when an iCloud download stalls and the result/completion handler is never invoked, `event.wait()`
(default `timeout=None`) **blocks the calling thread forever** — 0% CPU, no progress, un-interruptible
short of killing the process. This PR bounds each wait with a configurable per-request timeout
(default 300s; env override; `0` restores today's behavior) and raises a new `PhotoKitTimeoutError`.
**96 insertions, 3 deletions** (one source file + a new library-free test). Validated deterministically.

## How we hit it
A daily, unattended ETL exports newly-added screenshots from Photos. On a healthy day it finishes in
**~15 minutes**. It began **routinely taking 1–2+ hours, and several runs hung *indefinitely*** — the
whole job pinned behind a single `osxphotos export` sitting at **0% CPU, 0 files for 43–77 minutes**,
until a watchdog or a manual kill. (Possibly relevant: this library is ~24,300 photos of which
**~24,100 are iCloud-only** — only ~200 originals are local — so almost every export touches the
network path.)

## What we ruled out (so this isn't a misuse report)
We assumed it was *our* command for a long time and ran a controlled matrix in `/tmp` (never touching
the real export dir), adding one flag at a time to a known-good baseline: `--touch-file`, `--verbose`,
`--filename {uuid}`, `--from-date`, and **no `--limit`**. **Every variant completed in 74–142 s — none
reproduced the hang.** We also ran the literal production command to a seeded `/tmp` dir (121 s ✓) and
`--dry-run --update` against the real 28,000-file export directory (106 s ✓). The hang is
**non-deterministic** — it only happens when iCloud actually stalls — but the *failure mode* (an
**unbounded** wait on a network-backed handler) is deterministic and fixable.

**Experiment log (12 osxphotos invocations; 10 valid, 2 lost to our own script bugs):**

| # | experiment | result |
|---|---|---|
| 1 | local-only, `--limit 50` (baseline) | 122 s ✓ |
| 2 | + `--touch-file` | 99 s ✓ |
| 3 | + `--filename {uuid}` | 74 s ✓ |
| 4 | + `--verbose` | 92 s ✓ |
| 5 | + `--from-date 2024-06-01` | 98 s ✓ |
| 6 | **no `--limit`** (processed all 24,301; exported 194; `missing: 24,147`) | 95 s ✓ |
| 7 | literal production command → seeded `/tmp` dir | 121 s ✓ |
| 8 | `--dry-run --update` vs the real 28k-file dir | 106 s ✓ |
| 9 | validation of the fix (below) | 0.30 s ✓ |

## Root cause (`osxphotos/photokit.py`)
Three sites, identical shape:
```python
options.setNetworkAccessAllowed_(True)        # may fetch from iCloud
event = threading.Event()
def handler(...): ...; event.set()            # only fires on success
self._manager.requestImageDataAndOrientationForAsset_options_resultHandler_(...)
event.wait()                                  # ← no timeout: blocks FOREVER if the handler never fires
```
- `PhotoAsset._request_image_data` (`requestImageDataAndOrientationForAsset…`)
- `PhotoAsset._request_resource_data` (`requestDataForAssetResource…`)
- `VideoAsset._request_video_data` (`requestAVAssetForVideo…`)

## Validation (deterministic, library-free)
We couldn't reliably make iCloud stall on demand (cached assets resolve too fast), so we reproduced
the *exact* failure mode — a request whose completion handler is never invoked — and confirmed the
fix catches it. `tests/test_photokit_timeout.py` asserts:
```
PhotoKitTimeoutError raised after ~0.20s (handler never fires)   # bounded, not hung
returns without raising when the handler fires                   # no false timeout
PHOTOKIT_REQUEST_TIMEOUT == 0 restores wait-forever              # backward-compatible
```
All 4 tests pass in 0.34 s. We also confirmed a normal export still completes cleanly with no false
timeout under the default 300s.

## Honest scope (important)
In our *own* incident the command was `--download-missing` **without** `--use-photokit`, which we
later traced to the AppleScript/`photoscript` staging path (`_stage_photo_for_export_with_applescript`)
— a *different* mechanism from the one this PR fixes. So strictly, this PR fixes the **PhotoKit path**
(`--use-photokit`), which we validated above. We're flagging it because (a) it's a real unbounded-wait
bug regardless of how we tripped it, and (b) the AppleScript download path looks like it may have the
same "can block indefinitely" exposure (you already carry consecutive-failure/restart handling there),
which might be worth similar treatment. Happy to help look at that too if useful.

## The change
- New `PHOTOKIT_REQUEST_TIMEOUT` (default `300`), via `OSXPHOTOS_PHOTOKIT_TIMEOUT` env var; **`0`
  restores the exact legacy "wait forever" behavior.** An unbounded wait on a network operation is a
  latent hang-forever defect, so the default is finite; 300s is generous for a real iCloud download
  (even a large video) while still catching a true stall.
- New `PhotoKitTimeoutError(PhotoKitError)`.
- A small `_wait_for_event_or_timeout(event, asset_id)` helper, called from all three request sites.
- `tests/test_photokit_timeout.py` (needs no Photos library or network).

Deliberately small and self-contained so the default, the value, and how it's surfaced are easy for
you to adjust. Happy to also expose a `--timeout` CLI flag, or catch `PhotoKitTimeoutError` per-photo
in the export loop (skip + continue) — your call.

---

Looking forward to meeting you in person! And keep up all the great work!

Gene
