### PR TITLE
fix: handle Photos library discovery permission errors

### DIFF
--- a/osxphotos/cli/batch_edit.py
+++ b/osxphotos/cli/batch_edit.py
@@ -20,6 +20,7 @@ from osxphotos.sqlitekvstore import SQLiteKVStore
 from osxphotos.utils import pluralize
 
 from .cli_params import (
+    DB_OPTION,
     LIMITED_QUERY_OPTION_NAMES,
     LIMITED_QUERY_OPTIONS,
     THEME_OPTION,
@@ -114,6 +115,7 @@ from .verbose import verbose
     is_flag=True,
     help="Restores photo metadata to what it was prior to the last batch edit. May be combined with --dry-run to see what will be undone. Note: --undo cannot undo album changes at this time; photos added to an album with --add-to-album will remain in the album after --undo.",
 )
+@DB_OPTION
 @LIMITED_QUERY_OPTIONS
 @VERBOSE_OPTIONS
 @THEME_OPTION
@@ -129,6 +131,7 @@ def batch_edit(
     split_folder: str | None,
     dry_run: bool,
     undo: bool,
+    db: str | None,
     **kwargs: Any,
 ):
     """
@@ -179,7 +182,7 @@ def batch_edit(
         echo_error(f"[error] {e} Use --help for more information.")
         raise click.Abort()
 
-    photos = get_photos_for_processing(**kwargs)
+    photos = get_photos_for_processing(db=db, **kwargs)
     if not photos:
         # need this check here to avoid photosdb.photos() from retrieving all photos
         echo_error(
@@ -480,10 +483,11 @@ def render_album_template(
     return template_values
 
 
-def get_photos_for_processing(**kwargs) -> list[osxphotos.PhotoInfo]:
+def get_photos_for_processing(db: str | None = None, **kwargs) -> list[osxphotos.PhotoInfo]:
     """Get photos for processing from query options or selection.
 
     Args:
+        db: optional Photos library/database path.
         **kwargs: keyword arguments for query options or a subset thereof
 
     Returns: list of photos to process.
@@ -491,7 +495,7 @@ def get_photos_for_processing(**kwargs) -> list[osxphotos.PhotoInfo]:
     Raises:
         click.Abort if error getting selection.
     """
-    photosdb = osxphotos.PhotosDB()
+    photosdb = osxphotos.PhotosDB(dbfile=db)
     query_options = query_options_from_kwargs(**kwargs)
 
     # if any of the query options are specified, then operate over query results

--- a/osxphotos/cli/common.py
+++ b/osxphotos/cli/common.py
@@ -69,12 +69,20 @@ def get_photos_db(*db_options):
                 return db
 
     # if get here, no valid database paths passed, so try to figure out which to use
-    db = osxphotos.utils.get_last_library_path()
+    try:
+        db = osxphotos.utils.get_last_library_path()
+    except PermissionError as e:
+        click.echo(f"Could not read last opened Photos library preference: {e}", err=True)
+        db = None
     if db is not None:
         click.echo(f"Using last opened Photos library: {db}", err=True)
         return db
 
-    db = osxphotos.utils.get_system_library_path()
+    try:
+        db = osxphotos.utils.get_system_library_path()
+    except PermissionError as e:
+        click.echo(f"Could not read system Photos library preference: {e}", err=True)
+        db = None
     if db is not None:
         click.echo(f"Using system Photos library: {db}", err=True)
         return db

--- a/osxphotos/utils.py
+++ b/osxphotos/utils.py
@@ -179,8 +179,12 @@ def get_system_library_path() -> str | None:
         + "/Library/Containers/com.apple.photolibraryd/Data/Library/Preferences/com.apple.photolibraryd.plist"
     )
     if plist_file.is_file():
-        with open(plist_file, "rb") as fp:
-            pl = plistload(fp)
+        try:
+            with open(plist_file, "rb") as fp:
+                pl = plistload(fp)
+        except PermissionError as e:
+            logger.debug(f"could not read plist file: {str(plist_file)}: {e}")
+            return None
     else:
         logger.debug(f"could not find plist file: {str(plist_file)}")
         return None
@@ -196,8 +200,12 @@ def get_last_library_path() -> str | None:
         + "/Library/Containers/com.apple.Photos/Data/Library/Preferences/com.apple.Photos.plist"
     )
     if plist_file.is_file():
-        with open(plist_file, "rb") as fp:
-            pl = plistload(fp)
+        try:
+            with open(plist_file, "rb") as fp:
+                pl = plistload(fp)
+        except PermissionError as e:
+            logger.debug(f"could not read plist file: {str(plist_file)}: {e}")
+            return None
     else:
         logger.debug(f"could not find plist file: {str(plist_file)}")
         return None

--- a/tests/test_cli_batch_edit_library.py
+++ b/tests/test_cli_batch_edit_library.py
@@ -1,0 +1,60 @@
+"""Tests for --library support in osxphotos batch-edit."""
+
+from __future__ import annotations
+
+import pytest
+from click.testing import CliRunner
+
+from osxphotos.platform import is_macos
+
+if is_macos:
+    import importlib
+
+    batch_edit_module = importlib.import_module("osxphotos.cli.batch_edit")
+    batch_edit = batch_edit_module.batch_edit
+else:
+    pytest.skip(allow_module_level=True)
+
+
+def test_batch_edit_accepts_library_option_and_passes_it_to_processing(monkeypatch, tmp_path):
+    """batch-edit should accept --library like query/export and pass it through."""
+
+    library = tmp_path / "Photos Library.photoslibrary"
+    library.mkdir()
+    seen_kwargs = {}
+
+    class FakePhoto:
+        uuid = "FAKE-UUID"
+        date = None
+        original_filename = "fake.jpg"
+        keywords = []
+
+        def json(self):
+            return "{}"
+
+        def render_template(self, template, options=None):
+            return [template], None
+
+    def fake_get_photos_for_processing(**kwargs):
+        seen_kwargs.update(kwargs)
+        return [FakePhoto()]
+
+    monkeypatch.setattr(batch_edit_module, "get_photos_for_processing", fake_get_photos_for_processing)
+    monkeypatch.setattr(batch_edit_module, "save_photo_undo_info", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(batch_edit_module, "set_photo_keywords_from_template", lambda *_args, **_kwargs: None)
+
+    result = CliRunner().invoke(
+        batch_edit,
+        [
+            "--library",
+            str(library),
+            "--uuid",
+            "FAKE-UUID",
+            "--keyword",
+            "Sailing",
+            "--dry-run",
+        ],
+    )
+
+    assert result.exit_code == 0, result.output
+    assert seen_kwargs["db"] == str(library)

--- a/tests/test_library_discovery_permissions.py
+++ b/tests/test_library_discovery_permissions.py
@@ -1,0 +1,62 @@
+"""Tests for Photos library discovery under macOS TCC permission denial."""
+
+from __future__ import annotations
+
+import builtins
+import os
+
+from osxphotos import utils
+from osxphotos.cli.common import get_photos_db
+
+
+def _deny_open_for(filename_fragment: str, monkeypatch):
+    """Patch open so reads of filename_fragment raise PermissionError."""
+    real_open = builtins.open
+
+    def fake_open(file, *args, **kwargs):
+        if filename_fragment in os.fspath(file):
+            raise PermissionError("operation not permitted")
+        return real_open(file, *args, **kwargs)
+
+    monkeypatch.setattr(builtins, "open", fake_open)
+
+
+def test_library_discovery_returns_none_when_last_library_plist_permission_denied(monkeypatch, tmp_path):
+    """PermissionError reading Photos plist should behave like unavailable plist."""
+
+    plist = tmp_path / "Library/Containers/com.apple.Photos/Data/Library/Preferences/com.apple.Photos.plist"
+    plist.parent.mkdir(parents=True)
+    plist.write_bytes(b"blocked")
+
+    monkeypatch.setattr(utils.pathlib.Path, "home", classmethod(lambda cls: tmp_path))
+    _deny_open_for("com.apple.Photos.plist", monkeypatch)
+
+    assert utils.get_last_library_path() is None
+
+
+def test_library_discovery_returns_none_when_system_library_plist_permission_denied(monkeypatch, tmp_path):
+    """PermissionError reading photolibraryd plist should behave like unavailable plist."""
+
+    plist = tmp_path / "Library/Containers/com.apple.photolibraryd/Data/Library/Preferences/com.apple.photolibraryd.plist"
+    plist.parent.mkdir(parents=True)
+    plist.write_bytes(b"blocked")
+
+    monkeypatch.setattr(utils, "is_macos", True)
+    monkeypatch.setattr(utils, "get_macos_version", lambda: ("14", "0", "0"))
+    monkeypatch.setattr(utils.pathlib.Path, "home", classmethod(lambda cls: tmp_path))
+    _deny_open_for("com.apple.photolibraryd.plist", monkeypatch)
+
+    assert utils.get_system_library_path() is None
+
+
+def test_get_photos_db_falls_back_to_default_library_after_permission_denied(monkeypatch, tmp_path):
+    """get_photos_db should continue to ~/Pictures fallback if plist reads are TCC-blocked."""
+
+    fallback = tmp_path / "Pictures" / "Photos Library.photoslibrary"
+    fallback.mkdir(parents=True)
+
+    monkeypatch.setattr(utils, "get_last_library_path", lambda: (_ for _ in ()).throw(PermissionError("blocked last")))
+    monkeypatch.setattr(utils, "get_system_library_path", lambda: (_ for _ in ()).throw(PermissionError("blocked system")))
+    monkeypatch.setattr(os.path, "expanduser", lambda p: str(fallback) if p == "~/Pictures/Photos Library.photoslibrary" else p)
+
+    assert get_photos_db() == str(fallback)


### PR DESCRIPTION
## Summary
- Treat PermissionError while reading Photos preference plists as an unavailable preference, allowing library auto-discovery to fall through to the documented default Photos library path.
- Add --library/--db support to batch-edit and pass the explicit library path into PhotosDB.
- Add regression tests for TCC/permission-denied discovery fallback and batch-edit library option handling.

## Test plan
- PYTHONPATH=. ~/Pictures/HermesMediaIndex/.venv/bin/python -m pytest tests/test_library_discovery_permissions.py tests/test_cli_batch_edit_library.py -q
- PYTHONPATH=. ~/Pictures/HermesMediaIndex/.venv/bin/python -m osxphotos query --uuid-from-file ~/Pictures/HermesMediaIndex/july2025-pilot/out/current_test20_uuids.txt --count --mute
- PYTHONPATH=. ~/Pictures/HermesMediaIndex/.venv/bin/python -m osxphotos batch-edit --library "/Users/prashanthgangu/Pictures/Photos Library.photoslibrary" --uuid-from-file ~/Pictures/HermesMediaIndex/july2025-pilot/out/current_test20_uuids.txt --keyword Sailing --dry-run --verbose

## Context
On macOS, privacy/TCC can deny reads of the Photos and photolibraryd container preference plists even when the files exist and are owned by the current user. Before this change, the uncaught PermissionError stopped discovery before osxphotos could try the documented fallback ~/Pictures/Photos Library.photoslibrary. batch-edit also had no way to pass an explicit library path, unlike query/export.