### PR TITLE
Fix issue 2176: Allow wrapt major version 2:  wrapt>=2.0.0,<3.0.0

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       max-parallel: 4
       matrix:
-        os: [ubuntu-latest, macos-15]
+        os: [ubuntu-latest, macos-15, macos-26]
         # os: [macos-14]
         python-version: ['3.11', '3.12', '3.13', '3.14']
     steps:

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ toml>=0.10.2,<0.12.0
 tzdata
 utitools>=0.3.0
 whenever>=0.8.3,<0.9.0
-wrapt>=1.14.1,<=2.2.2
+wrapt>=2.0.0,<3.0.0
 wurlitzer>=3.0.2,<4.0.0
 xdg-base-dirs>=6.0.0; python_version >= '3.10'
 xdg==5.1.1; python_version <= '3.9'

--- a/requirements.txt
+++ b/requirements.txt
@@ -50,7 +50,7 @@ toml>=0.10.2,<0.12.0
 tzdata
 utitools>=0.3.0
 whenever>=0.8.3,<0.9.0
-wrapt>=1.14.1,<2.0.0
+wrapt>=1.14.1,<=2.2.2
 wurlitzer>=3.0.2,<4.0.0
 xdg-base-dirs>=6.0.0; python_version >= '3.10'
 xdg==5.1.1; python_version <= '3.9'

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,7 @@ setup(
         "tzdata",
         "utitools>=0.3.0",
         "whenever>=0.8.3,<0.9.0",
-        "wrapt>=1.14.1,<2.0.0",
+        "wrapt>=1.14.1,<=2.2.2",
         "wurlitzer>=3.0.2,<4.0.0",
         "xdg-base-dirs>=6.0.0; python_version >= '3.10'",
         "xdg==5.1.1; python_version <= '3.9'",

--- a/setup.py
+++ b/setup.py
@@ -135,7 +135,7 @@ setup(
         "tzdata",
         "utitools>=0.3.0",
         "whenever>=0.8.3,<0.9.0",
-        "wrapt>=1.14.1,<=2.2.2",
+        "wrapt>=2.0.0,<3.0.0",
         "wurlitzer>=3.0.2,<4.0.0",
         "xdg-base-dirs>=6.0.0; python_version >= '3.10'",
         "xdg==5.1.1; python_version <= '3.9'",


### PR DESCRIPTION
Allow wrapt major version 2:  wrapt>=2.0.0,<3.0.0

Fixes #2176

Adds macos26 to the test matrix. -- sorry, two changes in one go! I can split PRs if you want ;)!