### PR TITLE
Clean up library discovery permission handling

### DIFF
--- a/osxphotos/cli/batch_edit.py
+++ b/osxphotos/cli/batch_edit.py
@@ -163,6 +163,9 @@ def batch_edit(
     or 'osxphotos docs' for more information on the osxphotos template system.
 
     It is recommended you test your edits on a small set of photos before applying them to many photos.
+
+    Note: --library specifies which library photos are queried from but edits are always applied to the
+    library currently open in Photos. If you use --library, ensure the same library is open in Photos.
     """
 
     try:
@@ -483,7 +486,9 @@ def render_album_template(
     return template_values
 
 
-def get_photos_for_processing(db: str | None = None, **kwargs) -> list[osxphotos.PhotoInfo]:
+def get_photos_for_processing(
+    db: str | None = None, **kwargs
+) -> list[osxphotos.PhotoInfo]:
     """Get photos for processing from query options or selection.
 
     Args:

--- a/osxphotos/cli/common.py
+++ b/osxphotos/cli/common.py
@@ -92,20 +92,14 @@ def get_photos_db(*db_options):
                 return db
 
     # if get here, no valid database paths passed, so try to figure out which to use
-    try:
-        db = osxphotos.utils.get_last_library_path()
-    except PermissionError as e:
-        click.echo(f"Could not read last opened Photos library preference: {e}", err=True)
-        db = None
+    # get_last_library_path()/get_system_library_path() return None rather than
+    # raising if the preference file can't be read (e.g. blocked by macOS TCC)
+    db = osxphotos.utils.get_last_library_path()
     if db is not None:
         click.echo(f"Using last opened Photos library: {db}", err=True)
         return db
 
-    try:
-        db = osxphotos.utils.get_system_library_path()
-    except PermissionError as e:
-        click.echo(f"Could not read system Photos library preference: {e}", err=True)
-        db = None
+    db = osxphotos.utils.get_system_library_path()
     if db is not None:
         click.echo(f"Using system Photos library: {db}", err=True)
         return db

--- a/tests/test_cli_batch_edit_library.py
+++ b/tests/test_cli_batch_edit_library.py
@@ -16,7 +16,9 @@ else:
     pytest.skip(allow_module_level=True)
 
 
-def test_batch_edit_accepts_library_option_and_passes_it_to_processing(monkeypatch, tmp_path):
+def test_batch_edit_accepts_library_option_and_passes_it_to_processing(
+    monkeypatch, tmp_path
+):
     """batch-edit should accept --library like query/export and pass it through."""
 
     library = tmp_path / "Photos Library.photoslibrary"
@@ -39,9 +41,17 @@ def test_batch_edit_accepts_library_option_and_passes_it_to_processing(monkeypat
         seen_kwargs.update(kwargs)
         return [FakePhoto()]
 
-    monkeypatch.setattr(batch_edit_module, "get_photos_for_processing", fake_get_photos_for_processing)
-    monkeypatch.setattr(batch_edit_module, "save_photo_undo_info", lambda *_args, **_kwargs: None)
-    monkeypatch.setattr(batch_edit_module, "set_photo_keywords_from_template", lambda *_args, **_kwargs: None)
+    monkeypatch.setattr(
+        batch_edit_module, "get_photos_for_processing", fake_get_photos_for_processing
+    )
+    monkeypatch.setattr(
+        batch_edit_module, "save_photo_undo_info", lambda *_args, **_kwargs: None
+    )
+    monkeypatch.setattr(
+        batch_edit_module,
+        "set_photo_keywords_from_template",
+        lambda *_args, **_kwargs: None,
+    )
 
     result = CliRunner().invoke(
         batch_edit,

--- a/tests/test_library_discovery_permissions.py
+++ b/tests/test_library_discovery_permissions.py
@@ -8,55 +8,68 @@ import os
 from osxphotos import utils
 from osxphotos.cli.common import get_photos_db
 
+LAST_LIBRARY_PLIST = "Library/Containers/com.apple.Photos/Data/Library/Preferences/com.apple.Photos.plist"
+SYSTEM_LIBRARY_PLIST = "Library/Containers/com.apple.photolibraryd/Data/Library/Preferences/com.apple.photolibraryd.plist"
 
-def _deny_open_for(filename_fragment: str, monkeypatch):
-    """Patch open so reads of filename_fragment raise PermissionError."""
+
+def _write_plist(home, relative_path):
+    """Create a placeholder plist file below home."""
+    plist = home / relative_path
+    plist.parent.mkdir(parents=True, exist_ok=True)
+    plist.write_bytes(b"blocked")
+    return plist
+
+
+def _deny_open_for(monkeypatch, *filename_fragments):
+    """Patch open so reads of any of filename_fragments raise PermissionError."""
     real_open = builtins.open
 
     def fake_open(file, *args, **kwargs):
-        if filename_fragment in os.fspath(file):
+        if any(fragment in os.fspath(file) for fragment in filename_fragments):
             raise PermissionError("operation not permitted")
         return real_open(file, *args, **kwargs)
 
     monkeypatch.setattr(builtins, "open", fake_open)
 
 
-def test_library_discovery_returns_none_when_last_library_plist_permission_denied(monkeypatch, tmp_path):
+def test_get_last_library_path_returns_none_when_plist_permission_denied(
+    monkeypatch, tmp_path
+):
     """PermissionError reading Photos plist should behave like unavailable plist."""
-
-    plist = tmp_path / "Library/Containers/com.apple.Photos/Data/Library/Preferences/com.apple.Photos.plist"
-    plist.parent.mkdir(parents=True)
-    plist.write_bytes(b"blocked")
-
-    monkeypatch.setattr(utils.pathlib.Path, "home", classmethod(lambda cls: tmp_path))
-    _deny_open_for("com.apple.Photos.plist", monkeypatch)
+    _write_plist(tmp_path, LAST_LIBRARY_PLIST)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _deny_open_for(monkeypatch, "com.apple.Photos.plist")
 
     assert utils.get_last_library_path() is None
 
 
-def test_library_discovery_returns_none_when_system_library_plist_permission_denied(monkeypatch, tmp_path):
+def test_get_system_library_path_returns_none_when_plist_permission_denied(
+    monkeypatch, tmp_path
+):
     """PermissionError reading photolibraryd plist should behave like unavailable plist."""
-
-    plist = tmp_path / "Library/Containers/com.apple.photolibraryd/Data/Library/Preferences/com.apple.photolibraryd.plist"
-    plist.parent.mkdir(parents=True)
-    plist.write_bytes(b"blocked")
-
+    _write_plist(tmp_path, SYSTEM_LIBRARY_PLIST)
     monkeypatch.setattr(utils, "is_macos", True)
     monkeypatch.setattr(utils, "get_macos_version", lambda: ("14", "0", "0"))
-    monkeypatch.setattr(utils.pathlib.Path, "home", classmethod(lambda cls: tmp_path))
-    _deny_open_for("com.apple.photolibraryd.plist", monkeypatch)
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _deny_open_for(monkeypatch, "com.apple.photolibraryd.plist")
 
     assert utils.get_system_library_path() is None
 
 
-def test_get_photos_db_falls_back_to_default_library_after_permission_denied(monkeypatch, tmp_path):
+def test_get_photos_db_falls_back_to_default_library_when_plists_permission_denied(
+    monkeypatch, tmp_path
+):
     """get_photos_db should continue to ~/Pictures fallback if plist reads are TCC-blocked."""
-
+    _write_plist(tmp_path, LAST_LIBRARY_PLIST)
+    _write_plist(tmp_path, SYSTEM_LIBRARY_PLIST)
     fallback = tmp_path / "Pictures" / "Photos Library.photoslibrary"
     fallback.mkdir(parents=True)
 
-    monkeypatch.setattr(utils, "get_last_library_path", lambda: (_ for _ in ()).throw(PermissionError("blocked last")))
-    monkeypatch.setattr(utils, "get_system_library_path", lambda: (_ for _ in ()).throw(PermissionError("blocked system")))
-    monkeypatch.setattr(os.path, "expanduser", lambda p: str(fallback) if p == "~/Pictures/Photos Library.photoslibrary" else p)
+    monkeypatch.setattr(utils, "is_macos", True)
+    monkeypatch.setattr(utils, "get_macos_version", lambda: ("14", "0", "0"))
+    monkeypatch.setenv("HOME", str(tmp_path))
+    _deny_open_for(
+        monkeypatch, "com.apple.Photos.plist", "com.apple.photolibraryd.plist"
+    )
 
     assert get_photos_db() == str(fallback)


### PR DESCRIPTION
Follow-up to #2170. Small cleanups found while reviewing #2183 — no behavior change for users beyond the help text.

## Dead code in `get_photos_db()`

#2170 added `PermissionError` handlers around both discovery calls in `get_photos_db()`, but it also made `get_last_library_path()` and `get_system_library_path()` catch `PermissionError` themselves and return `None`. The handlers in `get_photos_db()` can't fire, so they're removed and replaced with a comment noting where the handling actually lives.

## Discovery permission tests

The tests added in #2170 monkeypatched the discovery functions to raise, which tested the `get_photos_db()` handlers rather than the fix in `utils.py`. Rewritten to exercise the real path — deny the plist reads by patching `open()` with `HOME` pointed at `tmp_path`:

- `get_last_library_path()` returns `None` when its plist read is blocked
- `get_system_library_path()` returns `None` when its plist read is blocked
- `get_photos_db()` falls through to `~/Pictures/Photos Library.photoslibrary` when both are blocked

All three fail if the `try`/`except` in `utils.py` is reverted, so they now pin the actual fix. Using `HOME` rather than patching `pathlib.Path.home` also covers `os.path.expanduser` in the `~/Pictures` fallback.

## `batch-edit --library` help text

#2170 added `--library` to `batch-edit`. The query runs against the given library, but the edits go through AppleScript to whichever library is open in Photos — so pointing `--library` at a different library silently edits the wrong one. Added a note to the command help. `sync` and `timewarp` have the same shape; leaving those alone for now.

Also ran `black` on `tests/test_cli_batch_edit_library.py`, which was committed unformatted.

Full suite: 2774 passed, 236 skipped, 8 xfailed, 4 xpassed. `black`, `isort`, `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BkxnZLosMFfBEKbrYjxaEr