### PR TITLE
Add missing index on export_data.uuid

### DIFF
--- a/osxphotos/export_db.py
+++ b/osxphotos/export_db.py
@@ -41,7 +41,7 @@ __all__ = [
     "ExportDBTemp",
 ]
 
-OSXPHOTOS_EXPORTDB_VERSION = "11.0"
+OSXPHOTOS_EXPORTDB_VERSION = "11.1"
 OSXPHOTOS_ABOUT_STRING = f"Created by osxphotos version {__version__} (https://github.com/RhetTbull/osxphotos) on {datetime.datetime.now()}"
 
 # max retry attempts for methods which use tenacity.retry
@@ -800,15 +800,6 @@ class ExportDB:
             c.execute("PRAGMA synchronous=NORMAL;")
             c.execute("PRAGMA cache_size=-100000;")
             c.execute("PRAGMA temp_store=MEMORY;")
-            # export_data has no index on uuid (only on filepath_normalized).
-            # get_target_for_file() queries by uuid to resolve filename
-            # collisions (e.g. "(1)", "(2)" suffixes), which without this
-            # index forces a full table scan on every call — measured at
-            # >0.6s per call on a ~150k-row table. This index cuts that same
-            # query to sub-millisecond. Safe/idempotent on every open.
-            c.execute(
-                "CREATE INDEX IF NOT EXISTS idx_export_data_uuid ON export_data(uuid);"
-            )
 
         return conn
 
@@ -991,6 +982,10 @@ class ExportDB:
 
         if current_version < float("11.0") and version >= float("11.0"):
             self._migrate_10_1_to_11_0(conn)
+
+        if current_version < float("11.1") and version >= float("11.1"):
+            # add index on export_data.uuid
+            self._migrate_11_0_to_11_1(conn)
 
         with self.lock:
             conn.execute("VACUUM;")
@@ -1384,6 +1379,23 @@ class ExportDB:
                 )
             conn.commit()
 
+    def _migrate_11_0_to_11_1(self, conn: sqlite3.Connection):
+        """Add index on export_data.uuid
+
+        export_data was indexed only on filepath_normalized but
+        get_target_for_file(), which resolves filename collisions (e.g. the
+        "(1)", "(2)" suffixes), queries by uuid; without this index every call
+        forces a full table scan of export_data (#2197).
+        """
+        with self.lock:
+            c = conn.cursor()
+            c.execute(
+                """ CREATE INDEX IF NOT EXISTS idx_export_data_uuid
+                    ON export_data (uuid);
+                    """
+            )
+            conn.commit()
+
     def _perform_db_maintenance(self, conn: sqlite3.Connection):
         """Perform database maintenance"""
         if float(self.version) < float("6.0"):
@@ -1525,9 +1537,6 @@ class ExportDBInMemory(ExportDB):
             self.was_created = True
             self.was_upgraded = ()
             self.version = OSXPHOTOS_EXPORTDB_VERSION
-            src.execute(
-                "CREATE INDEX IF NOT EXISTS idx_export_data_uuid ON export_data(uuid);"
-            )
             return src
 
         if version:
@@ -1550,13 +1559,6 @@ class ExportDBInMemory(ExportDB):
         else:
             self.was_upgraded = ()
         self.version = OSXPHOTOS_EXPORTDB_VERSION
-
-        # See ExportDB._open_export_db for why: export_data has no index on
-        # uuid, and get_target_for_file() (filename-collision resolution)
-        # queries by uuid, forcing a full table scan without it.
-        dst.execute(
-            "CREATE INDEX IF NOT EXISTS idx_export_data_uuid ON export_data(uuid);"
-        )
 
         return dst
 

--- a/osxphotos/export_db.py
+++ b/osxphotos/export_db.py
@@ -800,6 +800,15 @@ class ExportDB:
             c.execute("PRAGMA synchronous=NORMAL;")
             c.execute("PRAGMA cache_size=-100000;")
             c.execute("PRAGMA temp_store=MEMORY;")
+            # export_data has no index on uuid (only on filepath_normalized).
+            # get_target_for_file() queries by uuid to resolve filename
+            # collisions (e.g. "(1)", "(2)" suffixes), which without this
+            # index forces a full table scan on every call — measured at
+            # >0.6s per call on a ~150k-row table. This index cuts that same
+            # query to sub-millisecond. Safe/idempotent on every open.
+            c.execute(
+                "CREATE INDEX IF NOT EXISTS idx_export_data_uuid ON export_data(uuid);"
+            )
 
         return conn
 
@@ -1516,6 +1525,9 @@ class ExportDBInMemory(ExportDB):
             self.was_created = True
             self.was_upgraded = ()
             self.version = OSXPHOTOS_EXPORTDB_VERSION
+            src.execute(
+                "CREATE INDEX IF NOT EXISTS idx_export_data_uuid ON export_data(uuid);"
+            )
             return src
 
         if version:
@@ -1538,6 +1550,13 @@ class ExportDBInMemory(ExportDB):
         else:
             self.was_upgraded = ()
         self.version = OSXPHOTOS_EXPORTDB_VERSION
+
+        # See ExportDB._open_export_db for why: export_data has no index on
+        # uuid, and get_target_for_file() (filename-collision resolution)
+        # queries by uuid, forcing a full table scan without it.
+        dst.execute(
+            "CREATE INDEX IF NOT EXISTS idx_export_data_uuid ON export_data(uuid);"
+        )
 
         return dst
 

--- a/tests/test_export_db.py
+++ b/tests/test_export_db.py
@@ -1,4 +1,4 @@
-""" Test ExportDB """
+"""Test ExportDB"""
 
 import os
 import pathlib
@@ -494,3 +494,46 @@ def test_export_db_no_version(tmp_path):
     assert export_db.version == OSXPHOTOS_EXPORTDB_VERSION
     table_query = "SELECT * FROM sqlite_master WHERE type='table' AND name='history'"
     assert export_db.connection.execute(table_query).fetchall()
+
+
+INDEX_QUERY = (
+    "SELECT * FROM sqlite_master WHERE type='index' AND name='idx_export_data_uuid'"
+)
+
+
+def test_export_db_export_data_uuid_index(tmp_path):
+    """Test that index on export_data.uuid is created, #2197"""
+    test_db = tmp_path / "osxphotos_export.db"
+    export_db = ExportDB(test_db, tmp_path)
+    assert export_db.connection.execute(INDEX_QUERY).fetchall()
+
+
+def test_export_db_export_data_uuid_index_migration(tmp_path):
+    """Test that index on export_data.uuid is added on upgrade, #2197"""
+    test_db = tmp_path / "osxphotos_export.db"
+    export_db = ExportDB(test_db, tmp_path, version="11.0")
+    assert not export_db.connection.execute(INDEX_QUERY).fetchall()
+    export_db.close()
+
+    export_db = ExportDB(test_db, tmp_path)
+    assert export_db.was_upgraded
+    assert export_db.version == OSXPHOTOS_EXPORTDB_VERSION
+    assert export_db.connection.execute(INDEX_QUERY).fetchall()
+
+
+def test_export_db_old_version_no_export_data_table(tmp_path):
+    """Test that a db created with a version predating export_data can be created and upgraded, #2197"""
+    test_db = tmp_path / "osxphotos_export.db"
+    export_db = ExportDB(test_db, tmp_path, version="5.0")
+    assert export_db.version == "5.0"
+    table_query = (
+        "SELECT * FROM sqlite_master WHERE type='table' AND name='export_data'"
+    )
+    assert not export_db.connection.execute(table_query).fetchall()
+    export_db.close()
+
+    export_db = ExportDB(test_db, tmp_path)
+    assert export_db.was_upgraded
+    assert export_db.version == OSXPHOTOS_EXPORTDB_VERSION
+    assert export_db.connection.execute(table_query).fetchall()
+    assert export_db.connection.execute(INDEX_QUERY).fetchall()


### PR DESCRIPTION
Fixes #2197

get_target_for_file() resolves filename collisions (e.g. "(1)", "(2)" suffixes) by querying export_data WHERE uuid = ? AND filepath_normalized LIKE ?. export_data has an index on filepath_normalized but none on uuid, so SQLite falls back to a full table scan on every call (confirmed via EXPLAIN QUERY PLAN: SCAN export_data).

On a database with ~150k rows in export_data, this made the query take upwards of 0.6s per call, and since it's invoked for every photo involved in a filename collision, this alone could make --update runs take tens of minutes to hours on libraries with many such collisions.

Adding the index is purely additive and safe to apply unconditionally on every DB open (CREATE INDEX IF NOT EXISTS). A batch of 200 realistic get_target_for_file-style queries went from not completing within 120 seconds to 0.08 seconds total after adding it.

